### PR TITLE
RFC: IRI v1.8.1 cryptographic hash functions

### DIFF
--- a/text/0000-crypto/0000-crypto.md
+++ b/text/0000-crypto/0000-crypto.md
@@ -1,0 +1,54 @@
++ Feature name: `bee-crpyto`
++ Start date: 2019-10-15
++ RFC PR: [iotaledger/bee-rfcs#0000](https://github.com/iotaledger/bee-rfcs/pull/0000)
++ Bee issue: [iotaledger/bee#0000](https://github.com/iotaledger/bee/issues/0000)
+
+# Summary
+
+One paragraph explanation of the feature.
+
+# Motivation
+
+Why are we doing this? What use cases does it support? What is the expected
+outcome?
+
+1. Write a summary of the motivation.
+2. List all the specific use cases that your proposal is trying to address. 
+3. Where applicable, write from the perspective of the person who will be using
+   the software, for example using the "Job story" format:
+
+When ＿＿＿ , I want to ＿＿＿, so I can ＿＿＿.
+
++ **Example 1:** When I query a node for a list of transactions, I want to be
+  able to sort them by date, so I can work with the most relevant ones.
++ **Example 2:** When I configure a node, I want to be able to control how much
+  transaction history the node stores, so I can make sure I only store the data
+  I need without incurring additional operational costs.
+
+# Detailed design
+
+This is the bulk of the RFC. Explain the design in enough detail for somebody
+familiar with the IOTA and to understand, and for somebody familiar with Rust
+to implement. This should get into specifics and corner-cases, and include
+examples of how the feature is used.
+
+# Drawbacks
+
+Why should we *not* do this?
+
+# Rationale and alternatives
+
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not
+  choosing them?
+- What is the impact of not doing this?
+
+# Unresolved questions
+
+- What parts of the design do you expect to resolve through the RFC process
+  before this gets merged?
+- What parts of the design do you expect to resolve through the implementation
+  of this feature before stabilization?
+- What related issues do you consider out of scope for this RFC that could be
+  addressed in the future independently of the solution that comes out of this
+  RFC?

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -5,9 +5,11 @@
 
 # Summary
 
+<!-- TODO: 81 rounds? rounds of what? -->
+
 This RFC proposes the implementation of the cryptographic hash functions `CurlP` and `Kerl`. `CurlP81`, a newtype for
 `CurlP` with 81 rounds, and `Kerl` are the two cryptographic hash functions used by `iri v1.8.1`, the IOTA reference
-implementation. Both are sponge constructions, and thus follow a very similar structure.
+implementation. Both are sponge constructions, and thus follow a very similar architecture.
 
 In `iri v1.8.1`, `CurlP81` is used for generating transaction hashes and --- through the `PearlDiver` algorithm --- for
 proof of work calculations. `Kerl` on the other hand is used as part of all other operations requiring cryptographic
@@ -45,22 +47,22 @@ For example, a transaction that withdraws funds from an IOTA address needs to ha
 - transaction hash
 - nonce
 
-The cryptographic hash functions used in `iri v1.8.1` are `Curl-P-81` and `Kerl`, which are both sponge constructions.
+The cryptographic hash functions used in `iri v1.8.1` are `CurlP81` and `Kerl`, which are both sponge constructions.
 A simplistic (and not at all complete) summary is that these are functions that are equipped with a memory state and a
 function that replaces the state memory using some input string (which can be the state memory itself). A portion of the
 memory state is then the output. In the sponge metaphor, the process of replacing the memory state by an input string is
 said to *absorb* the input, while the process of producing an output is said to *squeeze out* an output.
 
-This RFC hence proposes to implement the `Curl` and `Kerl` sponge structures, with both being implement using the same
-or very similar function signatures. The shared interface is thus defined by convention, and there is no unifying
-`Sponge` trait.
+This RFC hence proposes to implement the `CurlP` and `Kerl` sponge structures, with both using the same or very similar
+function signatures. These types thus share a common interface, which is defined by convention, instead of relying on
+a unifying `Sponge` trait.
 
 The hashes are expected to be used like this:
 
 ```rust
-// Create a Curl instance with 81 rounds.
-// This is equivalent to calling `Curl::new(81)`.
-let mut curl = Curl::default();
+// Create a CurlP instance with 81 rounds.
+// This is equivalent to calling `CurlP::new(81)`.
+let mut curlp = CurlP::default();
 
 // Assume this is a transaction and we want to digest a hash.
 let transaction = [0i8; 8019];
@@ -78,7 +80,7 @@ curl.squeeze_into(&mut tx_hash);
 let mut kerl = Kerl::default();
 
 // `Kerl::digest` is a function that combines `Kerl::absorb` and `Kerl::squeeze`. `Kerl::digest_into`
-// combines `Kerl::absorb` with `Kerl::squeeze_into`. `Curl` provides the same methods.
+// combines `Kerl::absorb` with `Kerl::squeeze_into`. `CurlP` provides the same methods.
 let tx_hash = kerl.digest(&transaction);
 ```
 
@@ -279,23 +281,17 @@ impl Kerl {
 
 # Rationale and alternatives
 
-+ `Curl` and `Kerl` are fundamental to the `iri v1.8.1` main net. They are thus essential for compatibility with it.
-+ It is not clear if a `Sponge` trait as a unifying interface would find use. The similar interfaces between `Curl` and
-  `Kerl` are thus defined by convention.
-+ (TODO: fix this sentence) And they don't need to know how internal permutation and transformation work, just `squeeze`
-  the sponge and there will be a mutable reference as output. The internal state will
-+ This type is idiomatic in Rust. Users are not required to know the implement details of each hash algorithm.
-- We still have option to just use `Digest` crate, but it's parameters are all type of `u8`. IOTA use trits as basic
-  type which means this library may not fit our need. The ecosystem of this crate is also not fully mature yet. It may
-  be a burden to add another dependency.
-- Crypto community in Rust usually don't rely on native crates written all in Rust. Like
-  [sodiumoxide](https://github.com/sodiumoxide/sodiumoxide) is a Rust binding to
-  [libsodium](https://github.com/jedisct1/libsodium). There's also [ring](https://github.com/briansmith/ring) in
-  a hybrid of Rust, C, and assembly language which also expose a Rust API. However, utilize libraries like these will
-  also need to take care of different language bindings and their foreign function interface. There will be unsafe
-  scenarios have to consider more over. It will be better for us to stick with full Rust at the moment. In deed there's
-  RustCrypto community provides various crates and utilities like `Digest`. But like it states above, the ecosystem is
-  not truly mature yet. As this more low-level concern, we should make less dependency as possible.
++ `CurlP` and `Kerl` are fundamental to the `iri v1.8.1` main net. They are thus essential for compatibility with it.
++ In the context of `bee`, there is no use case for a `Sponge` trait at the moment. The similar interfaces between
+  `CurlP` and `Kerl` are thus defined by convention.
++ These types are idiomatic in Rust, and users are not required to know the implementation details of each hash
+  algorithm.
+
+## Alternatives
+
++ Providing a `Sponge` trait might be useful for consumers of the library if one wanted to be generic over what kind of
+  sponge construction some code uses. This is currently not a use case for `bee v0.1` or `iri v1.8.1`, however, and so
+  this proposal does not suggest it.
 
 # Unresolved questions
 

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -88,33 +88,45 @@ Useful links:
 
 # Detailed design
 
-This structure design is going to be the interface of any sponge function. Users can expect each hash instance would
-provide at least these public methods. Imagine it's like a real sponge, it `absorb`s the clone of input reference
-provided by users. And they don't need to know how internal permutation and transformation work, just `squeeze` the
-sponge and there will be a mutable reference as output. The internal state will not be cleared unless `reset` is called. 
+The sponges proposes in this RFC have a common interface, which consists of the functions below:
+
++ `fn absorb(&mut self, input: &[Trit])`;
++ `fn squeeze(&mut self) -> Vec<Trit>`;
++ `fn squeeze_into(&mut self, output: &mut [Trit])`;
++ `fn reset(&mut self)`;
++ `fn digest(&mut self, input: &[Trit]) -> Vec<Trit>`;
++ `fn digest_into(&mut self, input: &[Trit], output: &mut [Trit])`.
+
+This design is going to be the common interface of any sponge function. Users can expect each hash instance to provide
+at least these public methods. Following the sponge metaphor, an input reference provided by the user is `absorb`ed, and
+an output will be `squeeze`d from the data structure. `digest` is a convenience method calling `absorb` and `squeeze` in
+one go. The `*_into` versions of these methods are for providing a buffer into which the calculated hashes are written.
+The internal state will not be cleared unless `reset` is called. 
+
+## Detailed design using the `CurlP` example
+
+Using `CurlP` as an example, this section demonstrates what an implementation would look like.
 
 ```rust
 #[derive(Clone, Copy)]
 pub struct Curl {
+    /// The number of rounds of hashing to apply before a hash is squeezed.
     rounds: usize,
-    state: [Trit; STATE_LENGTH],
-}
 
-impl Default for Curl {
-    fn default() -> Curl {
-        Curl {
-            rounds: 81,
-            state: [0; STATE_LENGTH],
-        }
-    }
+    /// The internal state.
+    state: [Trit; STATE_LENGTH],
 }
 ```
 
-As defined above, a `Sponge` instance, take `Curl` for example, should be defined as a structure like this. What fields
-should have depend on each implementation. In this simple `Curl` strucutre, we just need a memory state and how many
-round should take. `Default` trait is set because we only uses 81 rounds at the moment. While `Sponge` trait doesn't
-care about thread safety and other concerns, we leave each type to decide which traits should also be included during
-implementation. The outcome should look like this:
+The default implementation of `CurlP` is always assumed to use 81 rounds:
+
+```rust
+impl Default for CurlP {
+    fn default() -> Self {
+        Self::new(81)
+    }
+}
+```
 
 ```rust
 
@@ -248,13 +260,6 @@ impl Kerl {
 }
 ```
 
- In summary, each sponge type must provide following public methods with similar signature:
-
-- `fn absorb(&mut self, input: &[Trit])`;
-- `fn squeeze(&mut self, output: &mut [Trit])`;
-- `fn reset(&mut self)`;
-- `fn digest (&mut self, input: &[Trit], output: &mut [Trit])`
-
 # Drawbacks
 
 - While users can use each types and methods directly, some might want to implement with some traits to benefit from
@@ -266,20 +271,22 @@ impl Kerl {
 # Rationale and alternatives
 
 + `Curl` and `Kerl` are fundamental to the `iri v1.8.1` main net. They are thus essential for compatibility with it.
-+ It is not clear if a `Sponge` trait as a unifying interface would find use. The similar interfaces between `Curl`
-  and `Kerl` are thus defined by convention.
++ It is not clear if a `Sponge` trait as a unifying interface would find use. The similar interfaces between `Curl` and
+  `Kerl` are thus defined by convention.
++ (TODO: fix this sentence) And they don't need to know how internal permutation and transformation work, just `squeeze`
+  the sponge and there will be a mutable reference as output. The internal state will
 + This type is idiomatic in Rust. Users are not required to know the implement details of each hash algorithm.
 - We still have option to just use `Digest` crate, but it's parameters are all type of `u8`. IOTA use trits as basic
   type which means this library may not fit our need. The ecosystem of this crate is also not fully mature yet. It may
-be a burden to add another dependency.
+  be a burden to add another dependency.
 - Crypto community in Rust usually don't rely on native crates written all in Rust. Like
   [sodiumoxide](https://github.com/sodiumoxide/sodiumoxide) is a Rust binding to
-[libsodium](https://github.com/jedisct1/libsodium). There's also [ring](https://github.com/briansmith/ring) in a hybrid
-of Rust, C, and assembly language which also expose a Rust API. However, utilize libraries like these will also need to
-take care of different language bindings and their foreign function interface. There will be unsafe scenarios have to
-consider more over. It will be better for us to stick with full Rust at the moment. In deed there's RustCrypto community
-provides various crates and utilities like `Digest`. But like it states above, the ecosystem is not truly mature yet. As
-this more low-level concern, we should make less dependency as possible.
+  [libsodium](https://github.com/jedisct1/libsodium). There's also [ring](https://github.com/briansmith/ring) in
+  a hybrid of Rust, C, and assembly language which also expose a Rust API. However, utilize libraries like these will
+  also need to take care of different language bindings and their foreign function interface. There will be unsafe
+  scenarios have to consider more over. It will be better for us to stick with full Rust at the moment. In deed there's
+  RustCrypto community provides various crates and utilities like `Digest`. But like it states above, the ecosystem is
+  not truly mature yet. As this more low-level concern, we should make less dependency as possible.
 
 # Unresolved questions
 

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -5,39 +5,43 @@
 
 # Summary
 
-One paragraph explanation of the feature.
+Hash functions in IOTA are sponge construction which usually hash an internal start to absorb input stream and output
+stream in any desired length after permutation. That means they all share similar structure we are able to abstract
+with. The goal of this RFC is to model this Sponge layer as trait. Making low-level hash algorithms provide same logic
+interface exposed to user, and let high-level module able to loosely couple from them.
 
 # Motivation
 
-Why are we doing this? What use cases does it support? What is the expected
-outcome?
-
-1. Write a summary of the motivation.
-2. List all the specific use cases that your proposal is trying to address. 
-3. Where applicable, write from the perspective of the person who will be using
-   the software, for example using the "Job story" format:
-
-When ＿＿＿ , I want to ＿＿＿, so I can ＿＿＿.
-
-+ **Example 1:** When I query a node for a list of transactions, I want to be
-  able to sort them by date, so I can work with the most relevant ones.
-+ **Example 2:** When I configure a node, I want to be able to control how much
-  transaction history the node stores, so I can make sure I only store the data
-  I need without incurring additional operational costs.
+It's true that everyone can just use each hash function they want directly. But we should still prevent from any of
+these algorithm is too tightly coupled to upper module when we integrate this. Take proof of work for example, it will
+have a module called PearlDiver mainly to deal with hashing. In the past, it already switched from curl-p to kerl.
+Imagine these two functions have totally different API, it would be difficult to refactor. Same thing is going to happen
+when we migrate to troika or other secure cryptography primitives in the future. So defining a trait for sponge is the
+best and necessary approach for us. 
 
 # Detailed design
 
-This is the bulk of the RFC. Explain the design in enough detail for somebody
-familiar with the IOTA and to understand, and for somebody familiar with Rust
-to implement. This should get into specifics and corner-cases, and include
-examples of how the feature is used.
+// TODO: Demonstrate what sponge construction is
+
+```rust 
+pub trait Sponge {
+	/// Absorb trits into the sponge
+	fn absorb(&mut self, trits: &[Trit]);
+	/// Squeeze trits out of the sponge and copy them into `out`
+	fn squeeze(&mut self, out: &mut [Trit]);
+	/// Reset the sponge to initial state
+	fn reset(&mut self);
+}
+```
 
 # Drawbacks
 
+// TODO
 Why should we *not* do this?
 
 # Rationale and alternatives
 
+// TODO
 - Why is this design the best in the space of possible designs?
 - What other designs have been considered and what is the rationale for not
   choosing them?
@@ -45,6 +49,7 @@ Why should we *not* do this?
 
 # Unresolved questions
 
+// TODO
 - What parts of the design do you expect to resolve through the RFC process
   before this gets merged?
 - What parts of the design do you expect to resolve through the implementation

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -100,29 +100,29 @@ The cryptographic hash functions in this RFC are implemented in terms of the `Sp
 ```rust
 trait Sponge {
     // Absorb `input` into the sponge
-    fn absorb(&mut self, input: &[u8]);
+    fn absorb(&mut self, input: &[i8]);
 
     // Reset the inner state of the sponge
     fn reset(&mut self);
 
     // Squeeze the sponge into a buffer
-    fn squeeze_into(&mut self, buf: &mut [u8])
+    fn squeeze_into(&mut self, buf: &mut [i8])
 
     // Squeeze the sponge and return the output
-    fn squeeze(&mut self) -> Vec<u8> {
+    fn squeeze(&mut self) -> Vec<i8> {
         let mut output: Vec::new();
         self.squeeze_into(&mut output);
         output
     }
 
     // Convenience function to absorb `input` and squeeze the sponge into a buffer in one go.
-    fn digest_into(&mut self, input: &[u8], buf: &mut [u8])
+    fn digest_into(&mut self, input: &[i8], buf: &mut [i8])
         self.absorb(input);
         self.squeeze_into(buf);
     }
 
     // Convenience function to absorb `input` and squeeze the sponge in one go, returning the output
-    fn digest(&mut self, input: &[u8]) -> Vec<u8> {
+    fn digest(&mut self, input: &[i8]) -> Vec<i8> {
         self.absorb(input);
         self.squeeze();
     }
@@ -148,7 +148,7 @@ const STATE_LENGTH: usize = HASH_LENGTH * 3;
 In addition, a lookup table is used as part of the absorption step:
 
 ```rust
-pub const TRUTH_TABLE: [Trit; 11] = [1, 0, -1, 2, 1, -1, 0, 2, -1, 1, 0];
+pub const TRUTH_TABLE: [i8; 11] = [1, 0, -1, 2, 1, -1, 0, 2, -1, 1, 0];
 ```
 
 **TODO:** Can we better explain the logic behind the truth table?
@@ -160,7 +160,7 @@ pub struct CurlP {
     rounds: usize,
 
     /// The internal state.
-    state: [u8; STATE_LENGTH],
+    state: [i8; STATE_LENGTH],
 }
 ```
 
@@ -170,7 +170,7 @@ impl CurlP {
     pub fn new(rounds: usize) -> Self {
         Self {
             rounds,
-            state: [Trit; STATE_LENGTH],
+            state: [i8; STATE_LENGTH],
         }
     }
 
@@ -180,7 +180,7 @@ impl CurlP {
     }
 
     fn transform(&mut self) {
-        let mut local_state: [Trit; STATE_LENGTH] = [0; STATE_LENGTH];
+        let mut local_state: [i8; STATE_LENGTH] = [0; STATE_LENGTH];
 
         for round in 0..self.rounds {
             let (state_out, state) = if round % 2 == 0 {
@@ -202,7 +202,7 @@ impl CurlP {
 
 ```rust
 impl Sponge for CurlP {
-    pub fn absorb(&mut self, input: &[u8]) {
+    pub fn absorb(&mut self, input: &[i8]) {
         for c in input.chunks(HASH_LENGTH) {
             self.state[0..c.len()].copy_from_slice(c);
             self.transform();
@@ -215,7 +215,7 @@ impl Sponge for CurlP {
     }
 
     /// Squeeze trits out of the sponge and copy them into `out`
-    pub fn squeeze_into(&mut self, buf: &mut [u8]) {
+    pub fn squeeze_into(&mut self, buf: &mut [i8]) {
         let trit_count = buf.len();
         let hash_count = trit_count / HASH_LENGTH;
 
@@ -268,9 +268,9 @@ impl Kerl {
 }
 
 impl Sponge for Kerl {
-    pub fn absorb(&mut self, trits: &[u8]) {
+    pub fn absorb(&mut self, trits: &[i8]) {
         assert_eq!(trits.len() % TRIT_LENGTH, 0);
-        let mut bytes: [u8; BYTE_LENGTH] = [0; BYTE_LENGTH];
+        let mut bytes: [i8; BYTE_LENGTH] = [0; BYTE_LENGTH];
 
         for chunk in trits.chunks(TRIT_LENGTH) {
             trits_to_bytes(chunk, &mut bytes);
@@ -278,9 +278,9 @@ impl Sponge for Kerl {
         }
     }
 
-    pub fn squeeze_into(&mut self, buf: &mut [u8]) {
+    pub fn squeeze_into(&mut self, buf: &mut [i8]) {
         assert_eq!(buf.len() % TRIT_LENGTH, 0);
-        let mut bytes: [u8; BYTE_LENGTH] = [0; BYTE_LENGTH];
+        let mut bytes: [i8; BYTE_LENGTH] = [0; BYTE_LENGTH];
 
         for chunk in buf.chunks_mut(TRIT_LENGTH) {
             self.0.pad();

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -21,14 +21,17 @@ best and necessary approach for us.
 
 # Detailed design
 
-// TODO: Demonstrate what sponge construction is
+This trait is going to be the interface of any sponge construction. Imagine it's like a real sponge, it `absorb`s the
+clone of input reference provided by users. And they don't need to know how internal permutation and transformation
+work, just `squeeze` the sponge and there will be a mutable reference as output. The internal state will not be cleared
+unless `reset` is called.
 
 ```rust 
 pub trait Sponge {
 	/// Absorb trits into the sponge
-	fn absorb(&mut self, trits: &[Trit]);
+    fn absorb<T: AsRef<[Trit]>>(&mut self, trits: T);
 	/// Squeeze trits out of the sponge and copy them into `out`
-	fn squeeze(&mut self, out: &mut [Trit]);
+	fn squeeze<T: AsMut<[Trit]>>(&mut self, out: T);
 	/// Reset the sponge to initial state
 	fn reset(&mut self);
 }

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -11,7 +11,7 @@ with. In current IRI and all supported client libraries in different language, `
 task. While `Curl` with 27 rounds is no longer used, `Curl` still handles proof of work and transaction hash generation.
 `Kerl` is responsible for the rest cryptography secure operations. There is also another hash function designed by
 Cryptocrypt which is still under cryptanalysis. Although we haven't determined to replace all tasks with `Troika`, we
-might also want to consider it when designing `Sponge` trait Espcially `Troika` doesn't use balanced trits as `Curl` and
+might also want to consider it when designing `Sponge` trait Especially `Troika` doesn't use balanced trits as `Curl` and
 `Kerl` do. The goal of this RFC is to model this Sponge layer as trait. Making low-level hash algorithms provide same
 logic interface exposed to users. 
 
@@ -52,12 +52,13 @@ let mut kerl = Kerl::default();
 // Same trait methods are called and signatures are not changed. Separate methods are still available.
 // kerl.absorb(&transaction);
 // kerl.squeeze(&mut tx_hash);
-kurl.digest(&transaction, &mut tx_hash);
+kerl.digest(&transaction, &mut tx_hash);
+
 ```
 
 # Detailed design
 
-This trait is going to be the interface of any sponge construction. Imagine it's like a real sponge, it `absorb`s the
+This trait is going to be the interface of any sponge function. Imagine it's like a real sponge, it `absorb`s the
 clone of input reference provided by users. And they don't need to know how internal permutation and transformation
 work, just `squeeze` the sponge and there will be a mutable reference as output. The internal state will not be cleared
 unless `reset` is called.
@@ -67,21 +68,85 @@ pub trait Sponge
 where
     Self: Default + Clone,
 {
-    type Item = Trit;
+    type Item;
 
     /// Absorb trits into the sponge
     fn absorb(&mut self, input: &[Self::Item]);
+    
     /// Squeeze trits out of the sponge and copy them into `out`
     fn squeeze(&mut self, output: &mut [Self::Item]);
+
     /// Reset the sponge to initial state
     fn reset(&mut self);
+
     /// Digest inputs and then compute the hash with length of provided output slice
     fn digest (&mut self, input: &[Self::Item], output: &mut [Self::Item]) {
         self.absorb(input);
         self.squeeze(output);
     }
 }
+
 ```
+
+As defined above, `Sponge` trait requires the type has trait bound of `Default` and `Clone` trait. iSince it doesn't
+contain any instance creation method, we require the type should at least have `Default` trait and any other method like
+`new` is optional in hope of giving flexibility. While `Sponge` trait doesn't care about thread safety and other
+concerns, we leave each type to decide which traits should also be included during implementation. Also note that
+default associated type isn't provided since it's still unstable feature for a long time. Consider our common crates
+should be compatible to stable, it should specify the type when implementing trait. The outcome should look like this:
+
+```rust
+impl Sponge for Curl
+where
+    Self: Send + 'static,
+{
+    type Item = Trit;
+
+    fn absorb(&mut self, input: &[Self::Item]) {
+        for c in input.chunks(HASH_LENGTH) {
+            self.state[0..c.len()].copy_from_slice(c);
+            self.transform();
+        }
+    }
+
+    fn squeeze(&mut self, output: &mut [Self::Item]) {
+        let trit_count = output.len();
+        let hash_count = trit_count / HASH_LENGTH;
+
+        for i in 0..hash_count {
+            output[i * HASH_LENGTH..(i + 1) * HASH_LENGTH]
+                .copy_from_slice(&self.state[0..HASH_LENGTH]);
+            self.transform();
+        }
+
+        let last = trit_count - hash_count * HASH_LENGTH;
+        output[trit_count - last..].copy_from_slice(&self.state[0..last]);
+        if trit_count % HASH_LENGTH != 0 {
+            self.transform();
+        }
+    }
+
+    fn reset(&mut self) {
+        self.state = [0; STATE_SIZE];
+    }
+}
+
+```
+
+With these trait and type all being defined, top layer modules are able to call them not only via their instance create
+methods directly but also with trait bound. While users can just call the required and provided methods like
+[Motivation](#Motivation) mentioned, we expect upper layer might want to be loosely coupled from actual hash algorithm.
+This is where trait bound can bring advantages. A signature for instance can just call trait methods without worrying
+its internal details:
+
+```rust
+impl Transaction {
+    pub fn sign<S: Sponge>(hasher: S) {
+        unimplemented!()
+    }
+}
+```
+
 # Drawbacks
 
 - Users may just want to use each function directly without methods of this trait.
@@ -104,13 +169,11 @@ where
 	hybrid of Rust, C, and assembly language which also expose a Rust API. However, utilize libraries like these will also
 	need to take care of different language bindings and their foreign function interface. There will be unsafe scenarios
 	have to consider more over. It will be better for us to stick with full Rust at the moment. In deed there's RustCrypto
-	community provides various crates and utilities like `Digest`. But like it states above, the ecosystem is not truely
-	mature yet. As this more low-level concer, we should make less dependency as possible.
+	community provides various crates and utilities like `Digest`. But like it states above, the ecosystem is not truly
+	mature yet. As this more low-level concern, we should make less dependency as possible.
 
 # Unresolved questions
 
-- Required and provided methods better resolve through RFC process. Do methods like `new` & `transform` also need to be
-	abstracted in `Sponge` trait?   
 - Parameters are slice reference in both input and output. Do we want to consume value or create a new instance as
 	return values?
 - Should we have low level traits defined like Digest? If so, should we also provide macro to implement these traits

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -5,33 +5,55 @@
 
 # Summary
 
-Hash functions in IOTA are sponge construction which usually hash an internal start to absorb input stream and output
-stream in any desired length after permutation. That means they all share similar structure we are able to abstract
-with. In current IRI and all supported client libraries in different language, `Curl` and `Kerl` are served in different
-task. While `Curl` with 27 rounds is no longer used, `Curl` still handles proof of work and transaction hash generation.
-`Kerl` is responsible for the rest cryptography secure operations. There is also another hash function designed by
-Cryptocrypt which is still under cryptanalysis. Although we haven't determined to replace all tasks with `Troika`, we
-might also want to consider it when designing `Sponge` trait Especially `Troika` doesn't use balanced trits as `Curl` and
-`Kerl` do. The goal of this RFC is to model this Sponge layer as trait. Making low-level hash algorithms provide same
-logic interface exposed to users. 
+This RFC proposes the implementation of the cryptographic hash functions `Curl-P-81` and `Kerl`, and a unifying `Sponge`
+trait. `Curl-P-81` and `Kerl` are the two cryptographic hash functions used by `iri v1.8.1`, the IOTA reference
+implementation. As both are sponge constructions, they share a similar structure amenable to abstraction.
+
+In `iri v1.8.1`, `Curl-P-81` is used for generating transaction hashes, and as the cryptographic hash function in
+`PearlDiver`, its proof of work algorithm. `Kerl` on the other hand is used as part of all other operations requiring
+cryptographic security, namely address generation, signature generation and verification, and bundle hash calculation.
 
 Useful links:
 
-- [The sponge and duplex constructions](https://keccak.team/sponge_duplex.html)
-- [Curl-p]()
-- [Kerl specification](https://github.com/iotaledger/kerl/blob/master/IOTA-Kerl-spec.md)
-- [Troika specification](https://www.cyber-crypt.com/troika/)
++ [The sponge and duplex constructions](https://keccak.team/sponge_duplex.html)
++ [Curl-p](...)
++ [Kerl specification](https://github.com/iotaledger/kerl/blob/master/IOTA-Kerl-spec.md)
++ [Troika specification](https://www.cyber-crypt.com/troika/)
++ [PearlDiver](...)
++ [`iri v1.8.1`](...)
+
 
 # Motivation
 
-It's true that everyone can just use each hash function they want directly. But we should still prevent from any of
-these algorithm is too tightly coupled to upper module when we integrate this. Take proof of work for example, it has a
-module called PearlDiver mainly to deal with hashing. The hash algorithm for PearlDiver is still `Curl`. But at the
-meantime, most of other tasks already switch from `Curl` to `Kerl`.  Imagine these two functions have totally different
-API, it would be difficult to refactor. Same thing is going to happen when we migrate to `Troika` or other secure
-cryptography primitives in the future. So defining a trait for sponge is the best and necessary approach for us. We
-expect users will still create each instance with each module structure methods but share same method signatures like
-this: 
+One goal of the `bee` project is to make it possible to write nodes that are able to run on the current main net of
+IOTA. Nodes comprising the current main net are implemented using the IOTA reference implementation, version `iri
+v1.8.1`, or using libraries compatible with it.
+
+In order to participate in the IOTA network, a node needs be able to construct valid messages that can be verified by
+other nodes in the network. Conversely, a node needs to be able to verify other nodes' messages. IOTA messages are
+called *bundles* and consist of one or more *transactions*. A transaction is a fixed-size binary object that itself is
+partitioned into several fixed-size fields. A *valid* transaction then is a transaction with fields containing correctly
+calculated hashes, signatures, and nonce values. For an overview of the different fields of a transaction, see the
+documents on [IOTA transactions and bundle].
+
+For example, a transaction that withdraws funds from an IOTA address needs to have the following set correctly:
+
+<!-- TODO: go into a bit more detail how and which hashes are used below -->
+
++ signature
++ address
++ bundle hash
++ transaction hash
++ nonce
+
+The cryptographic hash functions used in `iri v1.8.1` are `Curl-P-81` and `Kerl`, which are both sponge constructions.
+A simplistic (and not at all complete) summary is that these are functions that are equipped with a memory state and
+a function that replaces the state memory using some input string (which can be the state memory itself). A portion of
+the memory state is then the output. In the sponge metaphor, the process of replacing the memory state by an input
+string is said to *absorb* the input, while the process of producing an output is said to *squeeze out* an output.
+
+This RFC hence proposes to implement the `Curl-P-81` and `Kerl` sponges, together with a unifying `Sponge` trait. These
+are expected to be used like this:
 
 ```rust
 // Create a Curl instance with default rounds number which is 81.
@@ -45,7 +67,6 @@ let mut tx_hash = [0i8; 243];
 // curl.squeeze(&mut tx_hash);
 curl.digest(&transaction, &mut tx_hash);
 
-
 // That said we have `Kerl` and would like to hash with this instead.
 let mut kerl = Kerl::default();
 
@@ -53,8 +74,11 @@ let mut kerl = Kerl::default();
 // kerl.absorb(&transaction);
 // kerl.squeeze(&mut tx_hash);
 kerl.digest(&transaction, &mut tx_hash);
-
 ```
+
+Useful links:
+
++ [IOTA transactions and bundle](https://docs.iota.org/docs/dev-essentials/0.1/concepts/bundles-and-transactions)
 
 # Detailed design
 
@@ -171,6 +195,10 @@ impl Transaction {
 	have to consider more over. It will be better for us to stick with full Rust at the moment. In deed there's RustCrypto
 	community provides various crates and utilities like `Digest`. But like it states above, the ecosystem is not truly
 	mature yet. As this more low-level concern, we should make less dependency as possible.
+
+## Future work
+
++ Troika
 
 # Unresolved questions
 

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -5,9 +5,9 @@
 
 # Summary
 
-This RFC proposes the implementation of the cryptographic hash functions `Curl-P-81` and `Kerl`, and a unifying `Sponge`
-trait. `Curl-P-81` and `Kerl` are the two cryptographic hash functions used by `iri v1.8.1`, the IOTA reference
-implementation. As both are sponge constructions, they share a similar structure amenable to abstraction.
+This RFC proposes the implementation of the cryptographic hash functions `Curl-P-81` and `Kerl`, and a geneeal interface
+for public methods.  `Curl-P-81` and `Kerl` are the two cryptographic hash functions used by `iri v1.8.1`, the IOTA
+reference implementation. As both are sponge constructions, they share a similar structure amenable to abstraction.
 
 In `iri v1.8.1`, `Curl-P-81` is used for generating transaction hashes, and as the cryptographic hash function in
 `PearlDiver`, its proof of work algorithm. `Kerl` on the other hand is used as part of all other operations requiring
@@ -40,20 +40,20 @@ For example, a transaction that withdraws funds from an IOTA address needs to ha
 
 <!-- TODO: go into a bit more detail how and which hashes are used below -->
 
-+ signature
-+ address
-+ bundle hash
-+ transaction hash
-+ nonce
+- signature
+- address
+- bundle hash
+- transaction hash
+- nonce
 
 The cryptographic hash functions used in `iri v1.8.1` are `Curl-P-81` and `Kerl`, which are both sponge constructions.
-A simplistic (and not at all complete) summary is that these are functions that are equipped with a memory state and
-a function that replaces the state memory using some input string (which can be the state memory itself). A portion of
-the memory state is then the output. In the sponge metaphor, the process of replacing the memory state by an input
-string is said to *absorb* the input, while the process of producing an output is said to *squeeze out* an output.
+A simplistic (and not at all complete) summary is that these are functions that are equipped with a memory state and a
+function that replaces the state memory using some input string (which can be the state memory itself). A portion of the
+memory state is then the output. In the sponge metaphor, the process of replacing the memory state by an input string is
+said to *absorb* the input, while the process of producing an output is said to *squeeze out* an output.
 
-This RFC hence proposes to implement the `Curl-P-81` and `Kerl` sponges, together with a unifying `Sponge` trait. These
-are expected to be used like this:
+This RFC hence proposes to implement the `Curl-P-81` and `Kerl` sponge structures, together with same public methods.
+These are expected to be used like this:
 
 ```rust
 // Create a Curl instance with default rounds number which is 81.
@@ -62,7 +62,7 @@ let mut curl = Curl::default();
 let transaction = [0i8; 8019];
 let mut tx_hash = [0i8; 243];
 
-// `digest` is a provided method of Sponge which can separate with `absorb` & `squeeze` alternatively.
+// `digest` is a combined method of curl which can separate with `absorb` & `squeeze` alternatively.
 // curl.absorb(&transaction);
 // curl.squeeze(&mut tx_hash);
 curl.digest(&transaction, &mut tx_hash);
@@ -70,7 +70,7 @@ curl.digest(&transaction, &mut tx_hash);
 // That said we have `Kerl` and would like to hash with this instead.
 let mut kerl = Kerl::default();
 
-// Same trait methods are called and signatures are not changed. Separate methods are still available.
+// Same public methods are called and signatures are not changed. Separate methods are still available.
 // kerl.absorb(&transaction);
 // kerl.squeeze(&mut tx_hash);
 kerl.digest(&transaction, &mut tx_hash);
@@ -78,62 +78,52 @@ kerl.digest(&transaction, &mut tx_hash);
 
 Useful links:
 
-+ [IOTA transactions and bundle](https://docs.iota.org/docs/dev-essentials/0.1/concepts/bundles-and-transactions)
+- [IOTA transactions and bundle](https://docs.iota.org/docs/dev-essentials/0.1/concepts/bundles-and-transactions)
 
 # Detailed design
 
-This trait is going to be the interface of any sponge function. Imagine it's like a real sponge, it `absorb`s the
-clone of input reference provided by users. And they don't need to know how internal permutation and transformation
-work, just `squeeze` the sponge and there will be a mutable reference as output. The internal state will not be cleared
-unless `reset` is called.
-
-```rust 
-pub trait Sponge
-where
-    Self: Default + Clone,
-{
-    type Item;
-
-    /// Absorb trits into the sponge
-    fn absorb(&mut self, input: &[Self::Item]);
-    
-    /// Squeeze trits out of the sponge and copy them into `out`
-    fn squeeze(&mut self, output: &mut [Self::Item]);
-
-    /// Reset the sponge to initial state
-    fn reset(&mut self);
-
-    /// Digest inputs and then compute the hash with length of provided output slice
-    fn digest (&mut self, input: &[Self::Item], output: &mut [Self::Item]) {
-        self.absorb(input);
-        self.squeeze(output);
-    }
-}
-
-```
-
-As defined above, `Sponge` trait requires the type has trait bound of `Default` and `Clone` trait. iSince it doesn't
-contain any instance creation method, we require the type should at least have `Default` trait and any other method like
-`new` is optional in hope of giving flexibility. While `Sponge` trait doesn't care about thread safety and other
-concerns, we leave each type to decide which traits should also be included during implementation. Also note that
-default associated type isn't provided since it's still unstable feature for a long time. Consider our common crates
-should be compatible to stable, it should specify the type when implementing trait. The outcome should look like this:
+This structure design is going to be the interface of any sponge function. Users can expect each hash instance would
+provide at least these public methods. Imagine it's like a real sponge, it `absorb`s the clone of input reference
+provided by users. And they don't need to know how internal permutation and transformation work, just `squeeze` the
+sponge and there will be a mutable reference as output. The internal state will not be cleared unless `reset` is called. 
 
 ```rust
-impl Sponge for Curl
-where
-    Self: Send + 'static,
-{
-    type Item = Trit;
+#[derive(Clone, Copy)]
+pub struct Curl {
+    rounds: usize,
+    state: [Trit; STATE_LENGTH],
+}
 
-    fn absorb(&mut self, input: &[Self::Item]) {
+impl Default for Curl {
+    fn default() -> Curl {
+        Curl {
+            rounds: 81,
+            state: [0; STATE_LENGTH],
+        }
+    }
+}
+```
+
+As defined above, a `Sponge` instance, take `Curl` for example, should be defined as a structure like this. What fields
+should have depend on each implementation. In this simple `Curl` strucutre, we just need a memory state and how many
+round should take. `Default` trait is set because we only uses 81 rounds at the moment. While `Sponge` trait doesn't
+care about thread safety and other concerns, we leave each type to decide which traits should also be included during
+implementation. The outcome should look like this:
+
+```rust
+
+impl Curl {
+
+    /// Absorb trits into the sponge
+    pub fn absorb(&mut self, input: &[Trit]) {
         for c in input.chunks(HASH_LENGTH) {
             self.state[0..c.len()].copy_from_slice(c);
             self.transform();
         }
     }
 
-    fn squeeze(&mut self, output: &mut [Self::Item]) {
+    /// Squeeze trits out of the sponge and copy them into `out`
+    pub fn squeeze(&mut self, output: &mut [Trit]) {
         let trit_count = output.len();
         let hash_count = trit_count / HASH_LENGTH;
 
@@ -150,60 +140,144 @@ where
         }
     }
 
-    fn reset(&mut self) {
+    /// Reset the sponge to initial state
+    pub fn reset(&mut self) {
         self.state = [0; STATE_SIZE];
     }
-}
 
-```
+    /// Digest inputs and then compute the hash with length of provided output slice
+    pub fn digest (&mut self, input: &[Trit], output: &mut [Trit]) {
+        self.absorb(input);
+        self.squeeze(output);
+    }
 
-With these trait and type all being defined, top layer modules are able to call them not only via their instance create
-methods directly but also with trait bound. While users can just call the required and provided methods like
-[Motivation](#Motivation) mentioned, we expect upper layer might want to be loosely coupled from actual hash algorithm.
-This is where trait bound can bring advantages. A signature for instance can just call trait methods without worrying
-its internal details:
+    // Once general methods are defined, every types can implement any methods they want.
+    pub fn new(rounds: usize) -> Curl {
+        let mut curl = Curl::default();
+        curl.rounds = rounds;
+        curl
+    }
 
-```rust
-impl Transaction {
-    pub fn sign<S: Sponge>(hasher: S) {
-        unimplemented!()
+    pub fn state(&self) -> &[Trit] {
+        &self.state
+    }
+
+    fn transform(&mut self) {
+        let mut local_state: [Trit; STATE_LENGTH] = [0; STATE_LENGTH];
+
+        for round in 0..self.rounds {
+            let (state_out, state) = if round % 2 == 0 {
+                (&mut local_state, &self.state)
+            } else {
+                (&mut self.state, &local_state)
+            };
+
+            for state_index in 0..STATE_LENGTH {
+                let idx: usize = (state[TRANSFORM_INDICES[state_index]] as usize)
+                    .wrapping_add((state[TRANSFORM_INDICES[state_index + 1]] as usize) << 2)
+                    .wrapping_add(5);
+
+                state_out[state_index] = TRUTH_TABLE[idx];
+            }
+        }
     }
 }
+
 ```
+
+While this showcase should work, there might be more specific sponge type or even different hash algorithm suit for
+different use case.  The types in its fields and method signature by then may look different. No matter how each sponge
+type is implement, they should all provide public methods we mentioned above at least. Here is another example how
+`Kerl` should be implemented in similar manner:
+
+```rust
+#[derive(Clone, Copy)]
+// Kerl is wrapper for Keccak to hash ternary inputs
+pub struct Kerl(Keccak);
+
+impl Default for Kerl {
+    fn default() -> Kerl {
+        Kerl(Keccak::new_keccak384())
+    }
+}
+
+impl Kerl {
+    pub fn absorb(&mut self, trits: &[Trit]) {
+        assert_eq!(trits.len() % TRIT_LENGTH, 0);
+        let mut bytes: [u8; BYTE_LENGTH] = [0; BYTE_LENGTH];
+
+        for chunk in trits.chunks(TRIT_LENGTH) {
+            trits_to_bytes(chunk, &mut bytes);
+            self.0.update(&bytes);
+        }
+    }
+
+    pub fn squeeze(&mut self, out: &mut [Trit]) {
+        assert_eq!(out.len() % TRIT_LENGTH, 0);
+        let mut bytes: [u8; BYTE_LENGTH] = [0; BYTE_LENGTH];
+
+        for chunk in out.chunks_mut(TRIT_LENGTH) {
+            self.0.pad();
+            self.0.fill_block();
+            self.0.squeeze(&mut bytes);
+            self.reset();
+            bytes_to_trits(&mut bytes.to_vec(), chunk);
+            for b in bytes.iter_mut() {
+                *b = *b ^ 0xFF;
+            }
+            self.0.update(&bytes);
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.0 = Keccak::new_keccak384();
+    }
+
+    pub fn digest (&mut self, input: &[Trit], output: &mut [Trit]) {
+        self.absorb(input);
+        self.squeeze(output);
+    }
+
+    // ...Other public and private methods
+}
+```
+
+ In summary, each sponge type must provide following public methods with similar signature:
+
+- `fn absorb(&mut self, input: &[Trit])`;
+- `fn squeeze(&mut self, output: &mut [Trit])`;
+- `fn reset(&mut self)`;
+- `fn digest (&mut self, input: &[Trit], output: &mut [Trit])`
 
 # Drawbacks
 
-- Users may just want to use each function directly without methods of this trait.
-- This trait doesn't completely decouple implementation between layers. It just provides a common interface.
-- This trait only suit for sponge functions and also focus on ternary system. It might not be compatible to other binary
-	cryptography.
-- There is a sponge-less curl implementation optimized for performing proof of work. It might not be benefited from this
-	trait.
+- While users can use each types and methods directly, some might want to implement with some traits to benefit from
+  trait object and trait bound.
+- Type defined like this doesn't completely decouple implementation between layers. It just provides a common interface.
+- This type only suit for sponge functions and also focus on ternary system. It might not be compatible to other binary
+  cryptography in some edge case.
 
 # Rationale and alternatives
 
-- `Sponge` trait provide a common interface suit for any type of sponge functions.
-- This trait is idiomatic in Rust. Users are not required to know the implement details of each hash algorithm.
+- This kind of sponge type provide a common interface suit for any type of sponge functions.
+- This type is idiomatic in Rust. Users are not required to know the implement details of each hash algorithm.
 - We still have option to just use `Digest` crate, but it's parameters are all type of `u8`. IOTA use trits as basic
-	type which means this library may not fit our need. The ecosystem of this crate is also not fully mature yet. It may
-	be a burden to add another dependency.
+  type which means this library may not fit our need. The ecosystem of this crate is also not fully mature yet. It may
+be a burden to add another dependency.
 - Crypto community in Rust usually don't rely on native crates written all in Rust. Like
-	[sodiumoxide](https://github.com/sodiumoxide/sodiumoxide) is a Rust binding to
-	[libsodium](https://github.com/jedisct1/libsodium). There's also [ring](https://github.com/briansmith/ring) in a
-	hybrid of Rust, C, and assembly language which also expose a Rust API. However, utilize libraries like these will also
-	need to take care of different language bindings and their foreign function interface. There will be unsafe scenarios
-	have to consider more over. It will be better for us to stick with full Rust at the moment. In deed there's RustCrypto
-	community provides various crates and utilities like `Digest`. But like it states above, the ecosystem is not truly
-	mature yet. As this more low-level concern, we should make less dependency as possible.
-
-## Future work
-
-+ Troika
+  [sodiumoxide](https://github.com/sodiumoxide/sodiumoxide) is a Rust binding to
+[libsodium](https://github.com/jedisct1/libsodium). There's also [ring](https://github.com/briansmith/ring) in a hybrid
+of Rust, C, and assembly language which also expose a Rust API. However, utilize libraries like these will also need to
+take care of different language bindings and their foreign function interface. There will be unsafe scenarios have to
+consider more over. It will be better for us to stick with full Rust at the moment. In deed there's RustCrypto community
+provides various crates and utilities like `Digest`. But like it states above, the ecosystem is not truly mature yet. As
+this more low-level concern, we should make less dependency as possible.
 
 # Unresolved questions
 
 - Parameters are slice reference in both input and output. Do we want to consume value or create a new instance as
-	return values?
+  return values?
 - Should we have low level traits defined like Digest? If so, should we also provide macro to implement these traits
-	easily?
+  easily?
 - Implementation of each hash functions and other utilities like HMAC should have separate RFCs for them.
+- Decision on implementation of `Troika` is still unknown.

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -27,13 +27,21 @@ work, just `squeeze` the sponge and there will be a mutable reference as output.
 unless `reset` is called.
 
 ```rust 
-pub trait Sponge {
-	/// Absorb trits into the sponge
-    fn absorb<T: AsRef<[Trit]>>(&mut self, trits: T);
-	/// Squeeze trits out of the sponge and copy them into `out`
-	fn squeeze<T: AsMut<[Trit]>>(&mut self, out: T);
-	/// Reset the sponge to initial state
-	fn reset(&mut self);
+pub trait Sponge
+where
+    Self: Default + Clone + Send + 'static,
+{
+    /// Absorb trits into the sponge
+    fn absorb(&mut self, input: &[Trit]);
+    /// Squeeze trits out of the sponge and copy them into `out`
+    fn squeeze(&mut self, output: &mut [Trit]);
+    /// Reset the sponge to initial state
+    fn reset(&mut self);
+    /// Digest inputs and then compute the hash with length of provided output slice
+    fn digest (&mut self, input: &[Trit], output: &mut [Trit]) {
+        self.absorb(input);
+        self.squeeze(output);
+    }
 }
 ```
 # Drawbacks
@@ -51,7 +59,10 @@ pub trait Sponge {
 
 # Unresolved questions
 
-- Required and provided methods better resolve through RFC process.
+- Required and provided methods better resolve through RFC process. Do methods like `new` & `transform` also need to be
+	abstracted in `Sponge` trait?   
+- Parameters are slice reference in both input and output. Do we want to consume value or create a new instance as
+	return values?
 - Should we have low level traits defined like Digest? If so, should we also provide macro to implement these traits
 	easily?
 - Implementation of each hash functions and other utilities like HMAC should have separate RFCs for them.

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -249,7 +249,7 @@ struct CurlP81(CurlP);
 
 impl CurlP81 {
     pub fn new() -> Self {
-        Self(CurlP::new(27))
+        Self(CurlP::new(81))
     }
 }
 ```

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -66,7 +66,7 @@ let transaction = [0i8; 8019];
 let mut tx_hash = [0i8; 243];
 
 // Absorb the transaction.
-curlp.absorb(&transaction);
+curlp.absorb(&Trits::from_i8_unchecked(&transaction));
 // And squeeze into the `tx_hash` buffer.
 curlp.squeeze_into(&mut tx_hash);
 ```
@@ -85,44 +85,55 @@ Useful links:
 
 # Detailed design
 
-The cryptographic hash functions in this RFC are implemented in terms of the `Sponge` trait:
+The main proposal of this RFC are the `Sponge` trait and the `CurlP` and `Kerl`
+types that are implemented in terms of it. Additionally, this RFC includes the `Trits`,
+`TritsMut`, and `TritsBuf` types to represent balanced binary-coded ternary in the `t1b1`
+representation (which means that one trit is represented by one byte).
 
 ```rust
+/// The common interface of cryptographic hash functions that follow the sponge construction and that
+/// act on ternary.
 trait Sponge {
-    // Absorb `input` into the sponge
-    fn absorb(&mut self, input: &[i8]);
+    /// Absorb `input` into the sponge
+    fn absorb(&mut self, input: &Trits);
 
-    // Reset the inner state of the sponge
+    /// Reset the inner state of the sponge
     fn reset(&mut self);
 
-    // Squeeze the sponge into a buffer
-    fn squeeze_into(&mut self, buf: &mut [i8])
+    /// Squeeze the sponge into a buffer
+    fn squeeze_into(&mut self, buf: &mut TritsMut);
 
-    // Squeeze the sponge and return the output
-    fn squeeze(&mut self) -> Vec<i8> {
+    /// Squeeze the sponge and construct a new output
+    fn squeeze(&mut self) -> TritsBuf {
         let mut output: Vec::new();
         self.squeeze_into(&mut output);
         output
     }
 
-    // Convenience function to absorb `input` and squeeze the sponge into a buffer in one go.
-    fn digest_into(&mut self, input: &[i8], buf: &mut [i8])
+    // Convenience function to absorb `input`, squeeze the sponge into a
+    // buffer, and reset the sponge.
+    fn digest_into(&mut self, input: &Trits, buf: &mut TritsMut);
         self.absorb(input);
         self.squeeze_into(buf);
+        self.reset();
     }
 
-    // Convenience function to absorb `input` and squeeze the sponge in one go, returning the output
-    fn digest(&mut self, input: &[i8]) -> Vec<i8> {
+    // Convenience function to absorb `input`, squeeze the sponge constructing
+    // a new output, and reseting the sponge.
+    fn digest(&mut self, input: &Trits) -> TritsBuf {
         self.absorb(input);
         self.squeeze();
+        self.reset();
     }
 }
 ```
 
-at least these public methods. Following the sponge metaphor, an input reference provided by the user is `absorb`ed, and
-an output will be `squeeze`d from the data structure. `digest` is a convenience method calling `absorb` and `squeeze` in
-one go. The `*_into` versions of these methods are for providing a buffer into which the calculated hashes are written.
-The internal state will not be cleared unless `reset` is called. 
+Following the sponge metaphor, an input reference provided by the user is
+`absorb`ed, and an output will be `squeeze`d from the data structure. `digest`
+is a convenience method calling `absorb` and `squeeze` in one go. The `*_into`
+versions of these methods are for passing a buffer into which the calculated
+hashes are written.  The internal state will not be cleared unless `reset` is
+called. 
 
 ## Design of `CurlP`
 
@@ -138,6 +149,8 @@ const STATE_LENGTH: usize = HASH_LENGTH * 3;
 In addition, a lookup table is used as part of the absorption step. 2 is used to pad the table since there are only 9
 combinations should be taken:
 
+<!-- TODO: Convert this to a `TritsBuf` -->
+
 ```rust
 pub const TRUTH_TABLE: [i8; 11] = [1, 0, -1, 2, 1, -1, 0, 2, -1, 1, 0];
 ```
@@ -149,7 +162,7 @@ pub struct CurlP {
     rounds: usize,
 
     /// The internal state.
-    state: [i8; STATE_LENGTH],
+    state: TritsBuf,
 }
 ```
 
@@ -159,7 +172,7 @@ impl CurlP {
     pub fn new(rounds: usize) -> Self {
         Self {
             rounds,
-            state: [i8; STATE_LENGTH],
+            state: TritsBuf::with_capacity(STATE_LENGTH),
         }
     }
 
@@ -169,7 +182,7 @@ impl CurlP {
     }
 
     fn transform(&mut self) {
-        let mut local_state: [i8; STATE_LENGTH] = [0; STATE_LENGTH];
+        let mut local_state = TritsBuf::with_capacity(STATE_LENGTH);
 
         for round in 0..self.rounds {
             let (state_out, state) = if round % 2 == 0 {
@@ -179,7 +192,8 @@ impl CurlP {
             };
 
             for state_index in 0..STATE_LENGTH {
-                let idx: usize = (state[TRANSFORM_INDICES[state_index]] as usize)
+                let idx: usize =
+                    (state[TRANSFORM_INDICES[state_index]] as usize)
                     .wrapping_add((state[TRANSFORM_INDICES[state_index + 1]] as usize) << 2)
                     .wrapping_add(5);
 
@@ -191,7 +205,7 @@ impl CurlP {
 
 ```rust
 impl Sponge for CurlP {
-    pub fn absorb(&mut self, input: &[i8]) {
+    pub fn absorb(&mut self, input: &Trits) {
         for c in input.chunks(HASH_LENGTH) {
             self.state[0..c.len()].copy_from_slice(c);
             self.transform();
@@ -200,7 +214,7 @@ impl Sponge for CurlP {
 
     /// Reset the sponge to initial state
     pub fn reset(&mut self) {
-        self.state = [0; STATE_SIZE];
+        self.state = TritsBuf::with_capacity(STATE_SIZE);
     }
 
     /// Squeeze trits out of the sponge and copy them into `out`
@@ -290,6 +304,74 @@ impl Sponge for Kerl {
 }
 ```
 
+## Design of binary-coded ternary
+
+`TritsBuf`, `Trits`, and `TritsMut` are intended to be thin newtype wrappers around
+`Vec<i8>`, `&[i8]`, and `&mut [i8]` to ensure that the containers only contain
+valid data.
+
+Conversion from these types are implemented in terms of `TryFrom`, which checks
+if each integer is `-1`, `0`, or `+1`. The newtypes also contain escape hatches
+from the validation prior to conversion in the form of the `from_u8_unchecked`
+and `from_i8_unchecked` methods. These are provided for when performance is a concern,
+which is expected to be the case as these hashing functions will be used in tight loops.
+
+Given that these types are wrappers around `Vec` and slices, they should implement all
+traits that makes them usable in a similar way. This RFC doesn't provide example implementations,
+but the following is a non-exhaustive list of traits that will be required (in particular, for
+conveniently implementing the sponges presented here):
+
++ `std::ops::Index` and the associated `std::slice::SliceIndex`;
++ `std::ops::Deref` to derefence a `TritsBuf` into `Trits`;
++ `std::iter::Iterator`;
+
+```rust
+pub struct TritsBuf(Vec<i8>);
+pub struct Trits<'a>(&'a [i8]);
+pub struct TritsMut<'a>(&'a mut [i8]);
+
+struct FromU8Error;
+struct FromI8Error;
+
+// Similar impls for `TritsMut` and `TritsBuf`
+impl<'a> Trits<'a> {
+    pub fn from_i8_unchecked(v: &[i8]) -> Self {
+        Trits(v)
+    }
+
+    pub fn from_u8_unchecked(v: &[u8]) -> Self {
+        from_i8_unchecked(unsafe {
+            &*(self as *const _ as *const [i8])
+        })
+    }
+}
+
+impl TritsBuf {
+    /// Create a new `TritsBuf` with a number of `capacity` elements, all
+    /// initialized to 0;
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(vec![0; usize])
+    }
+}
+
+
+impl<'_> TryFrom<&'_ u8> for Trits {
+    type Error = FromU8Error;
+
+    fn try_from(self) -> Result<Trits, Self::Error> {
+        for byte in self {
+            match byte {
+                0b0000_0000 | 0b1111_1111 | 0b0000_0001 => {},
+                _ => Err(FromU8Error)?,
+            }
+        }
+
+        Ok( Trits::from_u8_unchecked(self) )
+        })
+    }
+}
+```
+
 # Drawbacks
 
 + Ternary is only handled within the crate as there is currently no common interface for it. Thus the present hashing
@@ -306,7 +388,8 @@ impl Sponge for Kerl {
 # Unresolved questions
 
 + Parameters are slice reference in both input and output. Do we want to consume value or create a new instance as
-+ return values?
+  return values?
 + Implementation of each hash functions and other utilities like HMAC should have separate RFCs for them.
 + Decision on implementation of `Troika` is still unknown.
 + Can (should?) the `CurlP` algorithm be explained in more detail?
++ The truth table should be expressed in terms of `TritsBuf`

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -109,7 +109,7 @@ Using `CurlP` as an example, this section demonstrates what an implementation wo
 
 ```rust
 #[derive(Clone, Copy)]
-pub struct Curl {
+pub struct CurlP {
     /// The number of rounds of hashing to apply before a hash is squeezed.
     rounds: usize,
 
@@ -129,8 +129,7 @@ impl Default for CurlP {
 ```
 
 ```rust
-
-impl Curl {
+impl CurlP {
 
     /// Absorb trits into the sponge
     pub fn absorb(&mut self, input: &[Trit]) {
@@ -140,8 +139,37 @@ impl Curl {
         }
     }
 
+    pub fn digest(&mut self, input: &[Trit]) -> Vec<Trit> {
+        self.absorb(input);
+        self.squeeze()
+    }
+
+    /// Digest inputs and then compute the hash with length of provided output slice
+    pub fn digest_into(&mut self, input: &[Trit], buf: &mut [Trit]) {
+        self.absorb(input);
+        self.squeeze_into(output);
+    }
+
+    pub fn new(rounds: usize) -> Self {
+        Self {
+            rounds,
+            state: [Trit; STATE_LENGTH],
+        }
+    }
+
+    /// Reset the sponge to initial state
+    pub fn reset(&mut self) {
+        self.state = [0; STATE_SIZE];
+    }
+
+    pub fn squeeze(&mut self) -> Vec<Trit> {
+        let mut output_buffer = Vec::new();
+        self.squeeze_into(&mut output_buffer);
+        output_buffer
+    }
+
     /// Squeeze trits out of the sponge and copy them into `out`
-    pub fn squeeze(&mut self, output: &mut [Trit]) {
+    pub fn squeeze_into(&mut self, buf: &mut [Trit]) {
         let trit_count = output.len();
         let hash_count = trit_count / HASH_LENGTH;
 
@@ -156,24 +184,6 @@ impl Curl {
         if trit_count % HASH_LENGTH != 0 {
             self.transform();
         }
-    }
-
-    /// Reset the sponge to initial state
-    pub fn reset(&mut self) {
-        self.state = [0; STATE_SIZE];
-    }
-
-    /// Digest inputs and then compute the hash with length of provided output slice
-    pub fn digest (&mut self, input: &[Trit], output: &mut [Trit]) {
-        self.absorb(input);
-        self.squeeze(output);
-    }
-
-    // Once general methods are defined, every types can implement any methods they want.
-    pub fn new(rounds: usize) -> Curl {
-        let mut curl = Curl::default();
-        curl.rounds = rounds;
-        curl
     }
 
     pub fn state(&self) -> &[Trit] {
@@ -200,7 +210,6 @@ impl Curl {
         }
     }
 }
-
 ```
 
 While this showcase should work, there might be more specific sponge type or even different hash algorithm suit for

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -5,21 +5,16 @@
 
 # Summary
 
-<!-- TODO: 81 rounds? rounds of what? -->
+This RFC proposes the implementation of the cryptographic hash functions `CurlP` and `Kerl`, and the `Sponge` trait as a
+common interface. The 3 cryptographic hash functions used by the IOTA reference implementation `iri v1.8.1` are `Kerl`,
+`CurlP27`, and `CurlP81`, the latter being newtypes around `CurlP` with 27 and 81 rounds (iterations of sponge function
+taken), respectively.
 
-This RFC proposes the implementation of the cryptographic hash functions
-`CurlP` and `Kerl`, and the `Sponge` trait as a common interface. The 3
-cryptographic hash functions used by the IOTA reference implementation `iri
-v1.8.1` are `Kerl`, `CurlP27`, and `CurlP81`, the latter being newtypes around
-`CurlP` with 27 and 81 rounds, respectively.
-
-`CurlP` is used for generating transaction hashes and --- through the
-`PearlDiver` algorithm --- for proof of work calculations. While `CurlP27` is
-used in the testnet, `CurlP81` is used for production in the mainnet. `Kerl` on
-the other hand is used as part of all other operations requiring cryptographic
-security, namely address generation, signature generation and verification, and
-bundle hash calculation. It is also used for coordinator to produce milestones
-on the mainnet.
+`CurlP` is used for generating transaction hashes and --- through the `PearlDiver` algorithm --- for proof of work
+calculations. While `CurlP27` is used in the testnet, `CurlP81` is used for production in the mainnet. `Kerl` on the
+other hand is used as part of all other operations requiring cryptographic security, namely address generation,
+signature generation and verification, and bundle hash calculation. It is also used for coordinator to produce
+milestones on the mainnet.
 
 This design is going to be the common interface of any sponge function. Users can expect each hash instance to provide
 Useful links:
@@ -46,23 +41,18 @@ documents on [IOTA transactions and bundle].
 
 For example, a transaction that withdraws funds from an IOTA address needs to have the following set correctly:
 
-<!-- TODO: go into a bit more detail how and which hashes are used below -->
+- [signatures](https://docs.iota.org/docs/getting-started/0.1/clients/signatures)
+- [addresses](https://docs.iota.org/docs/getting-started/0.1/clients/addresses)
+- [bundle hash (see Bundle essence)](https://docs.iota.org/docs/getting-started/0.1/transactions/bundles)
+- [nonce](https://docs.iota.org/docs/getting-started/0.1/transactions/proof-of-work)
 
-- signature
-- address
-- bundle hash
-- nonce
-
-The cryptographic hash functions used in `iri v1.8.1` are `CurlP27`, `CurlP81`,
-and `Kerl`, which are all sponge constructions. A simplistic (and not at all
-complete) summary is that these are functions that are equipped with a memory
-state and a function that replaces the state memory using some input string
-(which can be the state memory itself). A portion of the memory state is then
-the output. In the sponge metaphor, the process of replacing the memory state
-by an input string is said to *absorb* the input, while the process of
-producing an output is said to *squeeze out* an output.  This RFC hence
-proposes a `Sponge` trait, and the `CurlP` and `Kerl` sponge constructions that
-are implemented in terms of it.
+The cryptographic hash functions used in `iri v1.8.1` are `CurlP27`, `CurlP81`, and `Kerl`, which are all sponge
+constructions. A simplistic (and not at all complete) summary is that these are functions that are equipped with a
+memory state and a function that replaces the state memory using some input string (which can be the state memory
+itself). A portion of the memory state is then the output. In the sponge metaphor, the process of replacing the memory
+state by an input string is said to *absorb* the input, while the process of producing an output is said to *squeeze
+out* an output.  This RFC hence proposes a `Sponge` trait, and the `CurlP` and `Kerl` sponge constructions that are
+implemented in terms of it.
 
 The hashes are expected to be used like this:
 
@@ -145,13 +135,12 @@ const HASH_LENGTH: usize = 243;
 const STATE_LENGTH: usize = HASH_LENGTH * 3;
 ```
 
-In addition, a lookup table is used as part of the absorption step:
+In addition, a lookup table is used as part of the absorption step. 2 is used to pad the table since there are only 9
+combinations should be taken:
 
 ```rust
 pub const TRUTH_TABLE: [i8; 11] = [1, 0, -1, 2, 1, -1, 0, 2, -1, 1, 0];
 ```
-
-**TODO:** Can we better explain the logic behind the truth table?
 
 ```rust
 #[derive(Clone)]

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -7,14 +7,19 @@
 
 <!-- TODO: 81 rounds? rounds of what? -->
 
-This RFC proposes the implementation of the cryptographic hash functions `CurlP` and `Kerl`. `CurlP81`, a newtype for
-`CurlP` with 81 rounds, `CurlP27` with rounds, and `Kerl` are the two cryptographic hash functions used by `iri v1.8.1`,
-the IOTA reference implementation. All are sponge constructions, and thus follow a very similar architecture.
+This RFC proposes the implementation of the cryptographic hash functions
+`CurlP` and `Kerl`, and the `Sponge` trait as a common interface. The 3
+cryptographic hash functions used by the IOTA reference implementation `iri
+v1.8.1` are `Kerl`, `CurlP27`, and `CurlP81`, the latter being newtypes around
+`CurlP` with 27 and 81 rounds, respectively.
 
-In `iri v1.8.1`, `CurlP81`, `CurlP27` are used for generating transaction hashes and --- through the `PearlDiver`
-algorithm --- for proof of work calculations. `CurlP81` is used in mainnet, while `CurlP27` is used in testnet. `Kerl`
-on the other hand is used as part of all other operations requiring cryptographic security, namely address generation,
-signature generation and verification, and bundle hash calculation. It is also used for coordinator to produce milestones on the mainnet.
+`CurlP` is used for generating transaction hashes and --- through the
+`PearlDiver` algorithm --- for proof of work calculations. While `CurlP27` is
+used in the testnet, `CurlP81` is used for production in the mainnet. `Kerl` on
+the other hand is used as part of all other operations requiring cryptographic
+security, namely address generation, signature generation and verification, and
+bundle hash calculation. It is also used for coordinator to produce milestones
+on the mainnet.
 
 This design is going to be the common interface of any sponge function. Users can expect each hash instance to provide
 Useful links:
@@ -48,35 +53,36 @@ For example, a transaction that withdraws funds from an IOTA address needs to ha
 - bundle hash
 - nonce
 
-The cryptographic hash functions used in `iri v1.8.1` are `CurlP81`, `CurlP27`, and `Kerl`, which are all sponge
-constructions.  A simplistic (and not at all complete) summary is that these are functions that are equipped with a
-memory state and a function that replaces the state memory using some input string (which can be the state memory
-itself). A portion of the memory state is then the output. In the sponge metaphor, the process of replacing the memory
-state by an input string is said to *absorb* the input, while the process of producing an output is said to *squeeze
-out* an output.
-This RFC hence proposes a `Sponge` trait, and the `CurlP` and `Kerl` sponge constructions that are implemented in terms
-of it.
+The cryptographic hash functions used in `iri v1.8.1` are `CurlP27`, `CurlP81`,
+and `Kerl`, which are all sponge constructions. A simplistic (and not at all
+complete) summary is that these are functions that are equipped with a memory
+state and a function that replaces the state memory using some input string
+(which can be the state memory itself). A portion of the memory state is then
+the output. In the sponge metaphor, the process of replacing the memory state
+by an input string is said to *absorb* the input, while the process of
+producing an output is said to *squeeze out* an output.  This RFC hence
+proposes a `Sponge` trait, and the `CurlP` and `Kerl` sponge constructions that
+are implemented in terms of it.
 
 The hashes are expected to be used like this:
 
 ```rust
 // Create a CurlP instance with 81 rounds.
 // This is equivalent to calling `CurlP::new(81)`.
-let mut curlp = CurlP::default();
+let mut curlp = CurlP81::new();
 
 // Assume this is a transaction and we want to digest a hash.
 let transaction = [0i8; 8019];
 let mut tx_hash = [0i8; 243];
 
 // Absorb the transaction.
-curl.absorb(&transaction);
+curlp.absorb(&transaction);
 // And squeeze into the `tx_hash` buffer.
-curl.squeeze_into(&mut tx_hash);
+curlp.squeeze_into(&mut tx_hash);
 ```
 ```rust
-// Create a default Kerl instance. Kerl does not come with a configurable number of rounds, so that
-// `Kerl::new()` and `Kerl::default()` yield the same result.
-let mut kerl = Kerl::default();
+// Create a Kerl instance. Kerl does not come with a configurable number of rounds.
+let mut kerl = Kerl::new();
 
 // `Kerl::digest` is a function that combines `Kerl::absorb` and `Kerl::squeeze`. `Kerl::digest_into`
 // combines `Kerl::absorb` with `Kerl::squeeze_into`. `CurlP` provides the same methods.

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -53,9 +53,7 @@ function that replaces the state memory using some input string (which can be th
 memory state is then the output. In the sponge metaphor, the process of replacing the memory state by an input string is
 said to *absorb* the input, while the process of producing an output is said to *squeeze out* an output.
 
-This RFC hence proposes to implement the `CurlP` and `Kerl` sponge structures, with both using the same or very similar
-function signatures. These types thus share a common interface, which is defined by convention, instead of relying on
-a unifying `Sponge` trait.
+This RFC hence proposes a `Sponge` trait, and the `CurlP` and `Kerl` sponge constructions that are implemented in terms of it.
 
 The hashes are expected to be used like this:
 
@@ -73,7 +71,6 @@ curl.absorb(&transaction);
 // And squeeze into the `tx_hash` buffer.
 curl.squeeze_into(&mut tx_hash);
 ```
-
 ```rust
 // Create a default Kerl instance. Kerl does not come with a configurable number of rounds, so that
 // `Kerl::new()` and `Kerl::default()` yield the same result.
@@ -90,14 +87,42 @@ Useful links:
 
 # Detailed design
 
-The sponges proposes in this RFC have a common interface, which consists of the functions below:
+The cryptographic hash functions in this RFC are implemented in terms of the `Sponge` trait:
 
-+ `fn absorb(&mut self, input: &[Trit])`;
-+ `fn squeeze(&mut self) -> Vec<Trit>`;
-+ `fn squeeze_into(&mut self, output: &mut [Trit])`;
-+ `fn reset(&mut self)`;
-+ `fn digest(&mut self, input: &[Trit]) -> Vec<Trit>`;
-+ `fn digest_into(&mut self, input: &[Trit], output: &mut [Trit])`.
+```rust
+trait Sponge {
+    type Input;
+    type Output: Default;
+
+    // Absorb `input` into the sponge
+    fn absorb(&mut self, input: &Input);
+
+    // Reset the inner state of the sponge
+    fn reset(&mut self);
+
+    // Squeeze the sponge into a buffer
+    fn squeeze_into(&mut self, buffer: &mut Output)
+
+    // Squeeze the sponge and return the output
+    fn squeeze(&mut self) -> Output {
+        let mut output: Self::Output::default();
+        self.squeeze_into(&mut output);
+        output
+    }
+
+    // Convenience function to absorb `input` and squeeze the sponge into a buffer in one go.
+    fn digest_into(&mut self, input: &Input, buffer: &mut Output)
+        self.absorb(input);
+        self.squeeze_into(buffer);
+    }
+
+    // Convenience function to absorb `input` and squeeze the sponge in one go, returning the output
+    fn digest(&mut self, input: &Input) -> Output {
+        self.absorb(input);
+        self.squeeze();
+    }
+}
+```
 
 This design is going to be the common interface of any sponge function. Users can expect each hash instance to provide
 at least these public methods. Following the sponge metaphor, an input reference provided by the user is `absorb`ed, and
@@ -105,53 +130,39 @@ an output will be `squeeze`d from the data structure. `digest` is a convenience 
 one go. The `*_into` versions of these methods are for providing a buffer into which the calculated hashes are written.
 The internal state will not be cleared unless `reset` is called. 
 
-## Detailed design using the `CurlP` example
+## Design of `CurlP`
 
-Using `CurlP` as an example, this section demonstrates what an implementation would look like.
+`CurlP` is designed as a hash function that acts on `t1b1` binary-encoded
+ternary (meaning that one trit is encoded by one byte), with a hash length of `243` trits and an inner
+state of `729` trits, which we take as constants:
 
 ```rust
-#[derive(Clone, Copy)]
+const HASH_LENGTH: usize = 243;
+const STATE_LENGTH: usize = HASH_LENGTH * 3;
+```
+
+In addition, a lookup table is used as part of the absorption step:
+
+```rust
+pub const TRUTH_TABLE: [Trit; 11] = [1, 0, -1, 2, 1, -1, 0, 2, -1, 1, 0];
+```
+
+**TODO:** Can we better explain the logic behind the truth table?
+
+```rust
+#[derive(Clone)]
 pub struct CurlP {
     /// The number of rounds of hashing to apply before a hash is squeezed.
     rounds: usize,
 
     /// The internal state.
-    state: [Trit; STATE_LENGTH],
-}
-```
-
-The default implementation of `CurlP` is always assumed to use 81 rounds:
-
-```rust
-impl Default for CurlP {
-    fn default() -> Self {
-        Self::new(81)
-    }
+    state: [u8; STATE_LENGTH],
 }
 ```
 
 ```rust
 impl CurlP {
-
-    /// Absorb trits into the sponge
-    pub fn absorb(&mut self, input: &[Trit]) {
-        for c in input.chunks(HASH_LENGTH) {
-            self.state[0..c.len()].copy_from_slice(c);
-            self.transform();
-        }
-    }
-
-    pub fn digest(&mut self, input: &[Trit]) -> Vec<Trit> {
-        self.absorb(input);
-        self.squeeze()
-    }
-
-    /// Digest inputs and then compute the hash with length of provided output slice
-    pub fn digest_into(&mut self, input: &[Trit], buf: &mut [Trit]) {
-        self.absorb(input);
-        self.squeeze_into(output);
-    }
-
+    /// Create a new `CurlP` sponge with `rounds` of iterations.
     pub fn new(rounds: usize) -> Self {
         Self {
             rounds,
@@ -159,37 +170,9 @@ impl CurlP {
         }
     }
 
-    /// Reset the sponge to initial state
-    pub fn reset(&mut self) {
-        self.state = [0; STATE_SIZE];
-    }
-
-    pub fn squeeze(&mut self) -> Vec<Trit> {
-        let mut output_buffer = Vec::new();
-        self.squeeze_into(&mut output_buffer);
-        output_buffer
-    }
-
-    /// Squeeze trits out of the sponge and copy them into `out`
-    pub fn squeeze_into(&mut self, buf: &mut [Trit]) {
-        let trit_count = output.len();
-        let hash_count = trit_count / HASH_LENGTH;
-
-        for i in 0..hash_count {
-            output[i * HASH_LENGTH..(i + 1) * HASH_LENGTH]
-                .copy_from_slice(&self.state[0..HASH_LENGTH]);
-            self.transform();
-        }
-
-        let last = trit_count - hash_count * HASH_LENGTH;
-        output[trit_count - last..].copy_from_slice(&self.state[0..last]);
-        if trit_count % HASH_LENGTH != 0 {
-            self.transform();
-        }
-    }
-
-    pub fn state(&self) -> &[Trit] {
-        &self.state
+    /// Return the number of rounds used in this `CurlP` instacnce.
+    pub fn rounds(&self) -> usize {
+        self.usize
     }
 
     fn transform(&mut self) {
@@ -210,28 +193,85 @@ impl CurlP {
                 state_out[state_index] = TRUTH_TABLE[idx];
             }
         }
+}
+```
+
+```rust
+impl Sponge for CurlP {
+    type Input = [u8];
+    type Output = Vec<u8>;
+
+    pub fn absorb(&mut self, input: &Self::Input) {
+        for c in input.chunks(HASH_LENGTH) {
+            self.state[0..c.len()].copy_from_slice(c);
+            self.transform();
+        }
+    }
+
+    /// Reset the sponge to initial state
+    pub fn reset(&mut self) {
+        self.state = [0; STATE_SIZE];
+    }
+
+    /// Squeeze trits out of the sponge and copy them into `out`
+    pub fn squeeze_into(&mut self, buf: &mut Output) {
+        let trit_count = output.len();
+        let hash_count = trit_count / HASH_LENGTH;
+
+        for i in 0..hash_count {
+            output[i * HASH_LENGTH..(i + 1) * HASH_LENGTH]
+                .copy_from_slice(&self.state[0..HASH_LENGTH]);
+            self.transform();
+        }
+
+        let last = trit_count - hash_count * HASH_LENGTH;
+        output[trit_count - last..].copy_from_slice(&self.state[0..last]);
+        if trit_count % HASH_LENGTH != 0 {
+            self.transform();
+        }
     }
 }
 ```
 
-While this showcase should work, there might be more specific sponge type or even different hash algorithm suit for
-different use case.  The types in its fields and method signature by then may look different. No matter how each sponge
-type is implement, they should all provide public methods we mentioned above at least. Here is another example how
-`Kerl` should be implemented in similar manner:
+In addition, there are two wrapper types for the very common `CurlP` variants with `27` and `81`:
 
 ```rust
-#[derive(Clone, Copy)]
-// Kerl is wrapper for Keccak to hash ternary inputs
-pub struct Kerl(Keccak);
+struct CurlP27(CurlP);
 
-impl Default for Kerl {
-    fn default() -> Kerl {
-        Kerl(Keccak::new_keccak384())
+impl CurlP27 {
+    pub fn new() -> Self {
+        Self(CurlP::new(27))
     }
 }
 
+struct CurlP81(CurlP);
+
+impl CurlP81 {
+    pub fn new() -> Self {
+        Self(CurlP::new(27))
+    }
+}
+```
+
+
+## Design of `Kerl`
+
+```rust
+/// Kerl is wrapper for Keccak to hash ternary inputs.
+#[derive(Clone)]
+pub struct Kerl(Keccak);
+
 impl Kerl {
-    pub fn absorb(&mut self, trits: &[Trit]) {
+    pub fn new() -> Self {
+        Self(Keccak::new_keccak384())
+    }
+}
+
+impl Sponge for Kerl {
+    type Input = [u8];
+    type Output = Vec<u8>;
+
+    pub fn absorb(&mut self, trits: &Input) {
         assert_eq!(trits.len() % TRIT_LENGTH, 0);
         let mut bytes: [u8; BYTE_LENGTH] = [0; BYTE_LENGTH];
 
@@ -241,7 +281,7 @@ impl Kerl {
         }
     }
 
-    pub fn squeeze(&mut self, out: &mut [Trit]) {
+    pub fn squeeze_into(&mut self, out: &mut Output) {
         assert_eq!(out.len() % TRIT_LENGTH, 0);
         let mut bytes: [u8; BYTE_LENGTH] = [0; BYTE_LENGTH];
 
@@ -261,42 +301,26 @@ impl Kerl {
     pub fn reset(&mut self) {
         self.0 = Keccak::new_keccak384();
     }
-
-    pub fn digest (&mut self, input: &[Trit], output: &mut [Trit]) {
-        self.absorb(input);
-        self.squeeze(output);
-    }
-
-    // ...Other public and private methods
 }
 ```
 
 # Drawbacks
 
-+ Since we don't propose a trait, if a user wanted to be generic over some `T: Sponge`, they would need to implement
-  themselves.
 + Ternary is only handled within the crate as there is currently no common interface for it. Thus the present hashing
   functions will perform extra operations which is not ideal when called repeatedly.
 
 # Rationale and alternatives
 
 + `CurlP` and `Kerl` are fundamental to the `iri v1.8.1` main net. They are thus essential for compatibility with it.
-+ In the context of `bee`, there is no use case for a `Sponge` trait at the moment. The similar interfaces between
-  `CurlP` and `Kerl` are thus defined by convention.
 + These types are idiomatic in Rust, and users are not required to know the implementation details of each hash
   algorithm.
 
 ## Alternatives
 
-+ Providing a `Sponge` trait might be useful for consumers of the library if one wanted to be generic over what kind of
-  sponge construction some code uses. This is currently not a use case for `bee v0.1` or `iri v1.8.1`, however, and so
-  this proposal does not suggest it.
-
 # Unresolved questions
 
-- Parameters are slice reference in both input and output. Do we want to consume value or create a new instance as
-  return values?
-- Should we have low level traits defined like Digest? If so, should we also provide macro to implement these traits
-  easily?
-- Implementation of each hash functions and other utilities like HMAC should have separate RFCs for them.
-- Decision on implementation of `Troika` is still unknown.
++ Parameters are slice reference in both input and output. Do we want to consume value or create a new instance as
++ return values?
++ Implementation of each hash functions and other utilities like HMAC should have separate RFCs for them.
++ Decision on implementation of `Troika` is still unknown.
++ Can (should?) the `CurlP` algorithm be explained in more detail?

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -1,4 +1,4 @@
-+ Feature name: `bee-crpyto`
++ Feature name: `bee-hash`
 + Start date: 2019-10-15
 + RFC PR: [iotaledger/bee-rfcs#0000](https://github.com/iotaledger/bee-rfcs/pull/0000)
 + Bee issue: [iotaledger/bee#0000](https://github.com/iotaledger/bee/issues/0000)

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -8,12 +8,13 @@
 <!-- TODO: 81 rounds? rounds of what? -->
 
 This RFC proposes the implementation of the cryptographic hash functions `CurlP` and `Kerl`. `CurlP81`, a newtype for
-`CurlP` with 81 rounds, and `Kerl` are the two cryptographic hash functions used by `iri v1.8.1`, the IOTA reference
-implementation. Both are sponge constructions, and thus follow a very similar architecture.
+`CurlP` with 81 rounds, `CurlP27` with rounds, and `Kerl` are the two cryptographic hash functions used by `iri v1.8.1`,
+the IOTA reference implementation. All are sponge constructions, and thus follow a very similar architecture.
 
-In `iri v1.8.1`, `CurlP81` is used for generating transaction hashes and --- through the `PearlDiver` algorithm --- for
-proof of work calculations. `Kerl` on the other hand is used as part of all other operations requiring cryptographic
-security, namely address generation, signature generation and verification, and bundle hash calculation.
+In `iri v1.8.1`, `CurlP81`, `CurlP27` are used for generating transaction hashes and --- through the `PearlDiver`
+algorithm --- for proof of work calculations.  `CurlP81` is used in mainnet, while `CurlP27` is used in testnet. `Kerl`
+on the other hand is used as part of all other operations requiring cryptographic security, namely address generation,
+signature generation and verification, and bundle hash calculation.
 
 Useful links:
 
@@ -44,16 +45,16 @@ For example, a transaction that withdraws funds from an IOTA address needs to ha
 - signature
 - address
 - bundle hash
-- transaction hash
 - nonce
 
-The cryptographic hash functions used in `iri v1.8.1` are `CurlP81` and `Kerl`, which are both sponge constructions.
-A simplistic (and not at all complete) summary is that these are functions that are equipped with a memory state and a
-function that replaces the state memory using some input string (which can be the state memory itself). A portion of the
-memory state is then the output. In the sponge metaphor, the process of replacing the memory state by an input string is
-said to *absorb* the input, while the process of producing an output is said to *squeeze out* an output.
-
-This RFC hence proposes a `Sponge` trait, and the `CurlP` and `Kerl` sponge constructions that are implemented in terms of it.
+The cryptographic hash functions used in `iri v1.8.1` are `CurlP81`, `CurlP27`, and `Kerl`, which are all sponge
+constructions.  A simplistic (and not at all complete) summary is that these are functions that are equipped with a
+memory state and a function that replaces the state memory using some input string (which can be the state memory
+itself). A portion of the memory state is then the output. In the sponge metaphor, the process of replacing the memory
+state by an input string is said to *absorb* the input, while the process of producing an output is said to *squeeze
+out* an output.
+This RFC hence proposes a `Sponge` trait, and the `CurlP` and `Kerl` sponge constructions that are implemented in terms
+of it.
 
 The hashes are expected to be used like this:
 
@@ -115,6 +116,7 @@ trait Sponge {
         self.absorb(input);
         self.squeeze_into(buffer);
     }
+
 
     // Convenience function to absorb `input` and squeeze the sponge in one go, returning the output
     fn digest(&mut self, input: &Input) -> Output {

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -7,17 +7,53 @@
 
 Hash functions in IOTA are sponge construction which usually hash an internal start to absorb input stream and output
 stream in any desired length after permutation. That means they all share similar structure we are able to abstract
-with. The goal of this RFC is to model this Sponge layer as trait. Making low-level hash algorithms provide same logic
-interface exposed to user, and let high-level module able to loosely couple from them.
+with. In current IRI and all supported client libraries in different language, `Curl` and `Kerl` are served in different
+task. While `Curl` with 27 rounds is no longer used, `Curl` still handles proof of work and transaction hash generation.
+`Kerl` is responsible for the rest cryptography secure operations. There is also another hash function designed by
+Cryptocrypt which is still under cryptanalysis. Although we haven't determined to replace all tasks with `Troika`, we
+might also want to consider it when designing `Sponge` trait Espcially `Troika` doesn't use balanced trits as `Curl` and
+`Kerl` do. The goal of this RFC is to model this Sponge layer as trait. Making low-level hash algorithms provide same
+logic interface exposed to users. 
+
+Useful links:
+
+- [The sponge and duplex constructions](https://keccak.team/sponge_duplex.html)
+- [Curl-p]()
+- [Kerl specification](https://github.com/iotaledger/kerl/blob/master/IOTA-Kerl-spec.md)
+- [Troika specification](https://www.cyber-crypt.com/troika/)
 
 # Motivation
 
 It's true that everyone can just use each hash function they want directly. But we should still prevent from any of
-these algorithm is too tightly coupled to upper module when we integrate this. Take proof of work for example, it will
-have a module called PearlDiver mainly to deal with hashing. In the past, it already switched from curl-p to kerl.
-Imagine these two functions have totally different API, it would be difficult to refactor. Same thing is going to happen
-when we migrate to troika or other secure cryptography primitives in the future. So defining a trait for sponge is the
-best and necessary approach for us. 
+these algorithm is too tightly coupled to upper module when we integrate this. Take proof of work for example, it has a
+module called PearlDiver mainly to deal with hashing. The hash algorithm for PearlDiver is still `Curl`. But at the
+meantime, most of other tasks already switch from `Curl` to `Kerl`.  Imagine these two functions have totally different
+API, it would be difficult to refactor. Same thing is going to happen when we migrate to `Troika` or other secure
+cryptography primitives in the future. So defining a trait for sponge is the best and necessary approach for us. We
+expect users will still create each instance with each module structure methods but share same method signatures like
+this: 
+
+```rust
+// Create a Curl instance with default rounds number which is 81.
+let mut curl = Curl::default();
+// Assume this is a transaction and we want to digest a hash.
+let transaction = [0i8; 8019];
+let mut tx_hash = [0i8; 243];
+
+// `digest` is a provided method of Sponge which can separate with `absorb` & `squeeze` alternatively.
+// curl.absorb(&transaction);
+// curl.squeeze(&mut tx_hash);
+curl.digest(&transaction, &mut tx_hash);
+
+
+// That said we have `Kerl` and would like to hash with this instead.
+let mut kerl = Kerl::default();
+
+// Same trait methods are called and signatures are not changed. Separate methods are still available.
+// kerl.absorb(&transaction);
+// kerl.squeeze(&mut tx_hash);
+kurl.digest(&transaction, &mut tx_hash);
+```
 
 # Detailed design
 
@@ -29,16 +65,18 @@ unless `reset` is called.
 ```rust 
 pub trait Sponge
 where
-    Self: Default + Clone + Send + 'static,
+    Self: Default + Clone,
 {
+    type Item = Trit;
+
     /// Absorb trits into the sponge
-    fn absorb(&mut self, input: &[Trit]);
+    fn absorb(&mut self, input: &[Self::Item]);
     /// Squeeze trits out of the sponge and copy them into `out`
-    fn squeeze(&mut self, output: &mut [Trit]);
+    fn squeeze(&mut self, output: &mut [Self::Item]);
     /// Reset the sponge to initial state
     fn reset(&mut self);
     /// Digest inputs and then compute the hash with length of provided output slice
-    fn digest (&mut self, input: &[Trit], output: &mut [Trit]) {
+    fn digest (&mut self, input: &[Self::Item], output: &mut [Self::Item]) {
         self.absorb(input);
         self.squeeze(output);
     }
@@ -46,16 +84,28 @@ where
 ```
 # Drawbacks
 
-- Somebody may just want to use each function directly without methods of this trait.
-- This trait only suit for sponge functions and also focus on ternary system. It's not compatible to other binary
+- Users may just want to use each function directly without methods of this trait.
+- This trait doesn't completely decouple implementation between layers. It just provides a common interface.
+- This trait only suit for sponge functions and also focus on ternary system. It might not be compatible to other binary
 	cryptography.
+- There is a sponge-less curl implementation optimized for performing proof of work. It might not be benefited from this
+	trait.
 
 # Rationale and alternatives
 
 - `Sponge` trait provide a common interface suit for any type of sponge functions.
 - This trait is idiomatic in Rust. Users are not required to know the implement details of each hash algorithm.
 - We still have option to just use `Digest` crate, but it's parameters are all type of `u8`. IOTA use trits as basic
-	type which means this library may not fit our need.
+	type which means this library may not fit our need. The ecosystem of this crate is also not fully mature yet. It may
+	be a burden to add another dependency.
+- Crypto community in Rust usually don't rely on native crates written all in Rust. Like
+	[sodiumoxide](https://github.com/sodiumoxide/sodiumoxide) is a Rust binding to
+	[libsodium](https://github.com/jedisct1/libsodium). There's also [ring](https://github.com/briansmith/ring) in a
+	hybrid of Rust, C, and assembly language which also expose a Rust API. However, utilize libraries like these will also
+	need to take care of different language bindings and their foreign function interface. There will be unsafe scenarios
+	have to consider more over. It will be better for us to stick with full Rust at the moment. In deed there's RustCrypto
+	community provides various crates and utilities like `Digest`. But like it states above, the ecosystem is not truely
+	mature yet. As this more low-level concer, we should make less dependency as possible.
 
 # Unresolved questions
 

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -62,9 +62,10 @@ The hashes are expected to be used like this:
 // This is equivalent to calling `CurlP::new(81)`.
 let mut curlp81 = CurlP81::new();
 
-// Assume this is a transaction and we want to digest a hash.
-let transaction = [0i8; 8019];
-let mut tx_hash = [0i8; 243];
+// Assume we have some input that is a Trits slice as defined by
+// the bee_ternary crate, and an output buffer `TritBuf`:
+let transaction: &Trits<T1B1>;
+let mut tx_hash: TritBuf<T1B1Buf>;
 
 // Absorb the transaction.
 curlp.absorb(&Trits::from_i8_unchecked(&transaction));

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -273,11 +273,10 @@ impl Kerl {
 
 # Drawbacks
 
-- While users can use each types and methods directly, some might want to implement with some traits to benefit from
-  trait object and trait bound.
-- Type defined like this doesn't completely decouple implementation between layers. It just provides a common interface.
-- This type only suit for sponge functions and also focus on ternary system. It might not be compatible to other binary
-  cryptography in some edge case.
++ Since we don't propose a trait, if a user wanted to be generic over some `T: Sponge`, they would need to implement
+  themselves.
++ Ternary is only handled within the crate as there is currently no common interface for it. Thus the present hashing
+  functions will perform extra operations which is not ideal when called repeatedly.
 
 # Rationale and alternatives
 

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -5,16 +5,44 @@
 
 # Summary
 
-This RFC proposes the implementation of the cryptographic hash functions `CurlP` and `Kerl`, and the `Sponge` trait as a
-common interface. The 3 cryptographic hash functions used by the IOTA reference implementation `iri v1.8.1` are `Kerl`,
-`CurlP27`, and `CurlP81`, the latter being newtypes around `CurlP` with 27 and 81 rounds (iterations of sponge function
-taken), respectively.
+This RFC proposes the `Sponge` trait, and the implementation of the two
+cryptographic hash functions `CurlP` and `Kerl` in terms of it. The 3
+cryptographic hash functions used in IOTAs current main and dev nets (i.e. as
+of IOTA reference implementation `iri v1.8.1`) are `Kerl`, `CurlP27`, and
+`CurlP81`. With the bee project aiming to provide the building blocks for the
+implementation of nodes compatible with the current IOTA network, the provision
+of these sponge functions is essential.
 
-`CurlP` is used for generating transaction hashes and --- through the `PearlDiver` algorithm --- for proof of work
-calculations. While `CurlP27` is used in the testnet, `CurlP81` is used for production in the mainnet. `Kerl` on the
-other hand is used as part of all other operations requiring cryptographic security, namely address generation,
-signature generation and verification, and bundle hash calculation. It is also used for coordinator to produce
-milestones on the mainnet.
+# Motivation
+
+A core aim of the `bee` project is to make it possible to write nodes that are
+able to run on the current main net of IOTA. Nodes comprising the current main
+net are either implemented using the IOTA reference implementation, version
+`iri v1.8.1`, or using libraries compatible with it.
+
+In order to participate in the IOTA network, a node needs be able to construct
+valid messages that can be verified by other nodes in the network. Conversely,
+a node needs to be able to verify other nodes' messages. Among other
+operations, this is accomplished by checking transaction signatures (from which
+addresses are calculated), transaction hashes, and hashes of collections of
+transactions (so called bundles).
+
+The two hash functions currently used are sponge constructions: `CurlP`, which
+is specified entirely in ternary, and `Kerl`, which uses `keccak-384` after
+first converting ternary input to a binary representation, and then converts
+the squeezed binary hash back to ternary. For `CurlP` specifically, its variants
+`CurlP27` and `CurlP81` are used. The former is `CurlP` with 27 rounds and is employed
+in test nets, while the later uses 81 rounds and is used for production in the main net.
+
+`CurlP` and `Kerl` are so-called cryptographic sponge constructions.  A
+simplistic (and not at all complete) summary is that these are functions that
+are equipped with a memory state and a function that replaces the state memory
+using some input string (which can be the state memory itself). A portion of
+the memory state is then the output. In the sponge metaphor, the process of
+replacing the memory state by an input string is said to *absorb* the input,
+while the process of producing an output is said to *squeeze out* an output.
+This RFC hence proposes a `Sponge` trait, and the `CurlP` and `Kerl` sponge
+constructions that are implemented in terms of it.
 
 This design is going to be the common interface of any sponge function. Users can expect each hash instance to provide
 Useful links:
@@ -26,40 +54,13 @@ Useful links:
 + [PearlDiver](...)
 + [`iri v1.8.1`](...)
 
-# Motivation
-
-One goal of the `bee` project is to make it possible to write nodes that are able to run on the current main net of
-IOTA. Nodes comprising the current main net are either implemented using the IOTA reference implementation, version `iri
-v1.8.1`, or using libraries compatible with it.
-
-In order to participate in the IOTA network, a node needs be able to construct valid messages that can be verified by
-other nodes in the network. Conversely, a node needs to be able to verify other nodes' messages. IOTA messages are
-called *bundles* and consist of one or more *transactions*. A transaction is a fixed-size binary object that itself is
-partitioned into several fixed-size fields. A *valid* transaction then is a transaction with fields containing correctly
-calculated hashes, signatures, and nonce values. For an overview of the different fields of a transaction, see the
-documents on [IOTA transactions and bundle].
-
-For example, a transaction that withdraws funds from an IOTA address needs to have the following set correctly:
-
-- [signatures](https://docs.iota.org/docs/getting-started/0.1/clients/signatures)
-- [addresses](https://docs.iota.org/docs/getting-started/0.1/clients/addresses)
-- [bundle hash (see Bundle essence)](https://docs.iota.org/docs/getting-started/0.1/transactions/bundles)
-- [nonce](https://docs.iota.org/docs/getting-started/0.1/transactions/proof-of-work)
-
-The cryptographic hash functions used in `iri v1.8.1` are `CurlP27`, `CurlP81`, and `Kerl`, which are all sponge
-constructions. A simplistic (and not at all complete) summary is that these are functions that are equipped with a
-memory state and a function that replaces the state memory using some input string (which can be the state memory
-itself). A portion of the memory state is then the output. In the sponge metaphor, the process of replacing the memory
-state by an input string is said to *absorb* the input, while the process of producing an output is said to *squeeze
-out* an output.  This RFC hence proposes a `Sponge` trait, and the `CurlP` and `Kerl` sponge constructions that are
-implemented in terms of it.
 
 The hashes are expected to be used like this:
 
 ```rust
 // Create a CurlP instance with 81 rounds.
 // This is equivalent to calling `CurlP::new(81)`.
-let mut curlp = CurlP81::new();
+let mut curlp81 = CurlP81::new();
 
 // Assume this is a transaction and we want to digest a hash.
 let transaction = [0i8; 8019];
@@ -86,44 +87,57 @@ Useful links:
 # Detailed design
 
 The main proposal of this RFC are the `Sponge` trait and the `CurlP` and `Kerl`
-types that are implemented in terms of it. Additionally, this RFC includes the `Trits`,
-`TritsMut`, and `TritsBuf` types to represent balanced binary-coded ternary in the `t1b1`
-representation (which means that one trit is represented by one byte).
+types that are implemented in terms of it. This RFC relies on the the presence
+of the types `TritBuf` and `Trits`, which are assumed to be owning and
+borrowing collections of binary-coded ternary in the `T1B1` encoding (one trit
+per byte), similar to `PathBuf` and `Path`.
 
 ```rust
 /// The common interface of cryptographic hash functions that follow the sponge construction and that
 /// act on ternary.
 trait Sponge {
-    /// Absorb `input` into the sponge
-    fn absorb(&mut self, input: &Trits);
+    /// The expected length of the input to the sponge.
+    const IN_LEN: usize;
 
-    /// Reset the inner state of the sponge
+    /// The length of the hash squeezed from the sponge.
+    const OUT_LEN: usize;
+
+    /// An error indicating a that a failure has occured during `absorb`.
+    type Error;
+
+    /// Absorb `input` into the sponge.
+    fn absorb(&mut self, input: &Trits) -> Result<(), Self::Error>;
+
+    /// Reset the inner state of the sponge.
     fn reset(&mut self);
 
     /// Squeeze the sponge into a buffer
-    fn squeeze_into(&mut self, buf: &mut TritsMut);
+    fn squeeze_into(&mut self, buf: &mut Trits) -> Result<(), Self::Error>;
 
-    /// Squeeze the sponge and construct a new output
-    fn squeeze(&mut self) -> TritsBuf {
-        let mut output: Vec::new();
-        self.squeeze_into(&mut output);
-        output
+    /// Convenience function using `Sponge::squeeze_into` to to return an owned
+    /// version of the hash.
+    fn squeeze(&mut self) -> Result<TritBuf, Self::Error> {
+        let mut output = TritBuf::zeros(Self::OUT_LEN);
+        self.squeeze_into(&mut output)?;
+        Ok(output)
     }
 
-    // Convenience function to absorb `input`, squeeze the sponge into a
-    // buffer, and reset the sponge.
-    fn digest_into(&mut self, input: &Trits, buf: &mut TritsMut);
-        self.absorb(input);
-        self.squeeze_into(buf);
+    /// Convenience function to absorb `input`, squeeze the sponge into a
+    /// buffer, and reset the sponge in one go.
+    fn digest_into(&mut self, input: &Trits, buf: &mut Trits) -> Result<(), Self::Error> {
+        self.absorb(input)?;
+        self.squeeze_into(buf)?;
         self.reset();
+        Ok(())
     }
 
-    // Convenience function to absorb `input`, squeeze the sponge constructing
-    // a new output, and reseting the sponge.
-    fn digest(&mut self, input: &Trits) -> TritsBuf {
-        self.absorb(input);
-        self.squeeze();
+    /// Convenience function to absorb `input`, squeeze the sponge, and reset the sponge in one go.
+    /// Returns an owned versin of the hash.
+    fn digest(&mut self, input: &Trits) -> Result<TritBuf, Self::Error> {
+        self.absorb(input)?;
+        let output = self.squeeze()?;
         self.reset();
+        Ok(output)
     }
 }
 ```
@@ -137,103 +151,39 @@ called.
 
 ## Design of `CurlP`
 
-`CurlP` is designed as a hash function that acts on `t1b1` binary-encoded
-ternary (meaning that one trit is encoded by one byte), with a hash length of `243` trits and an inner
-state of `729` trits, which we take as constants:
+`CurlP` is designed as a hash function that acts on `T1B1` binary-encoded
+ternary, with a hash length of `243` trits and an inner state of `729` trits,
+which we take as constants:
 
 ```rust
 const HASH_LENGTH: usize = 243;
 const STATE_LENGTH: usize = HASH_LENGTH * 3;
 ```
 
-In addition, a lookup table is used as part of the absorption step. 2 is used to pad the table since there are only 9
-combinations should be taken:
-
-<!-- TODO: Convert this to a `TritsBuf` -->
+In addition, a lookup table is used as part of the absorption step. 2 is used
+to pad the table since there are only 9 combinations should be taken:
 
 ```rust
 pub const TRUTH_TABLE: [i8; 11] = [1, 0, -1, 2, 1, -1, 0, 2, -1, 1, 0];
 ```
 
+The way `CurlP` is defined, it can not actually fail, because the input or outputs can
+be of arbitrary size. Thus, the associated type `Error = !`, or `Error = Infallible` as `!`
+is not yet stabilized in Rust as of version `1.43`.
+
+We only give the type definition here. For the implementation, please refer to the prototype
+at [https://github.com/Alex6323/bee-p/blob/master/bee-crypto/src/curlp.rs].
+
 ```rust
-#[derive(Clone)]
 pub struct CurlP {
     /// The number of rounds of hashing to apply before a hash is squeezed.
     rounds: usize,
 
     /// The internal state.
-    state: TritsBuf,
-}
-```
+    state: TritBuf,
 
-```rust
-impl CurlP {
-    /// Create a new `CurlP` sponge with `rounds` of iterations.
-    pub fn new(rounds: usize) -> Self {
-        Self {
-            rounds,
-            state: TritsBuf::with_capacity(STATE_LENGTH),
-        }
-    }
-
-    /// Return the number of rounds used in this `CurlP` instacnce.
-    pub fn rounds(&self) -> usize {
-        self.usize
-    }
-
-    fn transform(&mut self) {
-        let mut local_state = TritsBuf::with_capacity(STATE_LENGTH);
-
-        for round in 0..self.rounds {
-            let (state_out, state) = if round % 2 == 0 {
-                (&mut local_state, &self.state)
-            } else {
-                (&mut self.state, &local_state)
-            };
-
-            for state_index in 0..STATE_LENGTH {
-                let idx: usize =
-                    (state[TRANSFORM_INDICES[state_index]] as usize)
-                    .wrapping_add((state[TRANSFORM_INDICES[state_index + 1]] as usize) << 2)
-                    .wrapping_add(5);
-
-                state_out[state_index] = TRUTH_TABLE[idx];
-            }
-        }
-}
-```
-
-```rust
-impl Sponge for CurlP {
-    pub fn absorb(&mut self, input: &Trits) {
-        for c in input.chunks(HASH_LENGTH) {
-            self.state[0..c.len()].copy_from_slice(c);
-            self.transform();
-        }
-    }
-
-    /// Reset the sponge to initial state
-    pub fn reset(&mut self) {
-        self.state = TritsBuf::with_capacity(STATE_SIZE);
-    }
-
-    /// Squeeze trits out of the sponge and copy them into `out`
-    pub fn squeeze_into(&mut self, buf: &mut [i8]) {
-        let trit_count = buf.len();
-        let hash_count = trit_count / HASH_LENGTH;
-
-        for i in 0..hash_count {
-            buf[i * HASH_LENGTH..(i + 1) * HASH_LENGTH]
-                .copy_from_slice(&self.state[0..HASH_LENGTH]);
-            self.transform();
-        }
-
-        let last = trit_count - hash_count * HASH_LENGTH;
-        buf[trit_count - last..].copy_from_slice(&self.state[0..last]);
-        if trit_count % HASH_LENGTH != 0 {
-            self.transform();
-        }
-    }
+    /// Workspace for performing transformations
+    work_state: TritBuf,
 }
 ```
 
@@ -259,123 +209,234 @@ impl CurlP81 {
 
 ## Design of `Kerl`
 
-```rust
-/// Kerl is wrapper for Keccak to hash ternary inputs.
-#[derive(Clone)]
-pub struct Kerl(Keccak);
+The actual cryptographic hash function underlying `Kerl` is `keccak-384`. The
+task here then is to transform an input of 243 (balanced) trits to 384 bits in
+a correct and performant way. This is done by interpreting the 243 trits as a
+signed integer `I` and converting it to a binary basis. In other words, the
+ternary coded integer is expressed as the series:
 
-impl Kerl {
-    pub fn new() -> Self {
-        Self(Keccak::new_keccak384())
-    }
+```
+I = t_0 * 3^0 + t_1 * 3^1 + ... + t_241 * 3^241 + t_242 * 3^242,
+```
+
+where `t_i` is the trit at the `i`-th position in the ternary input array. The
+challenge is then to convert this integer to base `2`, i.e. find a a series
+such that
+
+```
+I = b_0 * 2^0 + b_1 * 2^1 + ... + b_382 * 2^382 + b_383 * 2^383,
+```
+
+with `b_i` the bit at the `i-th` position.
+
+Assuming there exists an implementation of `keccak` (which is recommended given
+that one should rely on existing, battle-tested implementations of
+cryptographic hash functions and RNGs), the main work in implementing `Kerl` is
+thus writing an efficient converter between the ternary array interpreted as an
+integer, and its binary representation. For the binary representation, one can
+either use an existing big integer library, or write one from scratch with only
+a subset of required methods to make the conversion work.
+
+### Important implementation details
+
+There are a couple of important points to remember when writing `Kerl`, which are
+listed in this section. These are not always properly explained in existing `Kerl`
+implementations, and thus reading the code might be at times confusing. If one keeps
+these in mind the implementation becomes straight forward.
+
+#### Conversion is done via accumulation
+
+Because a number like `3^242` does not fit into any existing primitive, it needs to be constructed from
+scratch by taking a big integer, setting its least significant number to `1`, and multiplying it by `3`
+`242` times. This is the core of the conversion mechanism. Essentially, the polynomial used to
+express the integer in ternary can be rewritten like this:
+
+```
+I = t_0 * 3^0 + t_1 * 3^1 + ... + t_241 * 3^241 + t_242 * 3^242,
+  = ((...((t_242 * 3 + t_241) * 3 + t_240) * 3 + ...) * 3 + t_1) * 3 + t_0
+```
+
+Thus, one iterates through the ternary buffer starting from the most
+significant trit, adds `t_242` onto the binary big integer (initially filled
+with `0`s), and then keeps looping through it, multiplying it by 3 and adding
+the next `t_i`.
+
+
+#### Conversion is done in unsigned space
+
+First and foremost, IOTA is primarily written with balanced ternary in mind,
+meaning that each trit represents an integer in the set `{-1, 0, +1}`. Because
+it is easier to do the conversion in positive space, the trits are shifted into
+*unbalanced* space, by adding `+1` at each position, so that each unbalanced
+trit represents an integer in `{0, 1, 2}`.
+
+For example, the balanced ternary buffer (using only 9 trits to demonstrate the point)
+becomes after the shift (leaving out signs in the unbalanced case):
+
+```
+[0, -1, +1, -1, -1, 0, 0, 0, +1] -> [1, 0, 2, 0, 0, 1, 1, 1, 2]
+```
+
+Remembering that each ternary array is actually some integer `I`, this is akin to
+adding another integer `H` to it, with all trits in the ternary buffer representing it
+set to `1`, where `I'` is `I` shifted into unsigned space, and the underscore `_t` means
+a ternary representation (either balanced or unbalanced):
+
+```
+I_t + H_t = [0, -1, +1, -1, -1, 0, 0, 0, +1] + [+1, +1, +1, +1, +1, +1, +1, +1] = I'_t
+```
+
+After changing the base to binary using some function which we call `to_bin`
+and which we require to distribute over addition (because the base in which a
+number is represented should have no bearing over adding said numbers), `H` needs to
+be subtracted again. We use `_b` to signify a binary representation:
+
+```
+I'_b = to_bin(I'_t) = to_bin(I_t + H_t) = to_bin(I_t) + to_bin(H_t) = I_b + H_b
+=>
+I_b = I'_b - H_b
+```
+
+In other words, the addition of the ternary buffer filled with `1`s that shifts all trits
+into unbalanced space is reverted after conversion to binary, where the buffer of `1`s is
+also converted to binary and then subtracted from the binary unsigned big integer. The result
+then is the integer `I` in binary.
+
+#### 243 trits do not fit into 384 bits
+
+Since 243 do not fit into 384 bits, a choice has to be made about how to treat
+the most significant trit. For example, one could take the binary big integer,
+convert it to ternary, and then check if the 243 are smaller than this
+converted maximum 384 bit big int. With `Kerl`, the choice was made to
+disregard the most significant trit, so that one only ever converts 242 trits to 384
+bits, which always fits.
+
+For the direction `ternary -> binary` this does not pose challenges, other than making sure
+that one sets the most significant trit to `0` after the shift by applying `+1` (if one chooses
+to reuse the array of 243 tritS), and by making sure to subtract `H_b` (see previous section)
+with the most significant trit set to `0` and all others set to `1`.
+
+The direction `binary -> ternary` (the conversion of the 384-bit hash squeezed from keccak) is
+the confusing part: one needs to ensure that the most significant trit is is set to 0 before the
+binary-encoded integer is converted to ternary. However, this has to happen in binary space!
+
+Take `J_b` as the 384 bit integer coming out of the sponge. Then after conversion to ternary,
+`to_ter(J_b) = J_t`, the most significant trit (MST) of `J_t` might be `+1` or `-1`. However, since by
+convention the MST has to be 0, one needs to check whether `J_b` would cause `J_t` to have its MST
+set after conversion. This is done the following way:
+
+```
+if J_b > to_bin([0, 1, 1, ..., 1]):
+    J_b <- J_b - to_bin([1, 0, 0, ..., 0])
+
+if J_b < (to_bin([0, 0, 0, ..., 0]) - to_bin([0, 1, 1, ..., 1])):
+    J_b <- J_b + to_bin([1, 0, 0, ..., 0])
+```
+
+#### Kerl updates the inner state by applying logical not
+
+The upstream keccak implementation uses a complicated permutation to update the inner state
+of the sponge construction after a hash was squeezed from it. `Kerl` opts to apply logical not, `!`,
+to the bytes squeezed from `keccak`, and updating `keccak`'s inner state with these.
+
+### Design and implementation
+
+An example implementation of `Kerl` can be found in the `bee-prototype` crate at 
+[https://github.com/Alex6323/bee-p/blob/master/bee-crypto/src/kerl.rs]. The ternary to binary
+conversion can be found at [https://github.com/Alex6323/bee-p/tree/master/bee-ternary/src/bigint].
+
+The main goal of the implementation was to ensure that representation of the integer was cast into
+types. To that end, the following ternary types are defined as wrappers around `TritBuf` (read `T243`
+the same way you would think of `u32` or `i64`):
+
+```rust
+struct T242<T: Trit> {
+    inner: TritBuf<T1B1Buf<T>>,
 }
 
-impl Sponge for Kerl {
-    pub fn absorb(&mut self, trits: &[i8]) {
-        assert_eq!(trits.len() % TRIT_LENGTH, 0);
-        let mut bytes: [i8; BYTE_LENGTH] = [0; BYTE_LENGTH];
-
-        for chunk in trits.chunks(TRIT_LENGTH) {
-            trits_to_bytes(chunk, &mut bytes);
-            self.0.update(&bytes);
-        }
-    }
-
-    pub fn squeeze_into(&mut self, buf: &mut [i8]) {
-        assert_eq!(buf.len() % TRIT_LENGTH, 0);
-        let mut bytes: [i8; BYTE_LENGTH] = [0; BYTE_LENGTH];
-
-        for chunk in buf.chunks_mut(TRIT_LENGTH) {
-            self.0.pad();
-            self.0.fill_block();
-            self.0.squeeze(&mut bytes);
-            self.reset();
-            bytes_to_trits(&mut bytes.to_vec(), chunk);
-            for b in bytes.iter_mut() {
-                *b = *b ^ 0xFF;
-            }
-            self.0.update(&bytes);
-        }
-    }
-
-    pub fn reset(&mut self) {
-        self.0 = Keccak::new_keccak384();
-    }
+struct T243<T: Trit> {
+    inner: TritBuf<T1B1Buf<T>>,
 }
 ```
 
-## Design of binary-coded ternary
+where `TritBuf`, `T1B1Buf`, and `Trit` are types and traits defined in the `bee-ternary` crate. The bound
+`Trit` ensures that the structs only contain ternary buffers with `Btrit` (for balancer ternary), and `Utrit`
+(for unbalanced ternary). Methods on `T242` and `T243` assume that the most significant trit is always in the
+last position (think “little endian”).
 
-`TritsBuf`, `Trits`, and `TritsMut` are intended to be thin newtype wrappers around
-`Vec<i8>`, `&[i8]`, and `&mut [i8]` to ensure that the containers only contain
-valid data.
-
-Conversion from these types are implemented in terms of `TryFrom`, which checks
-if each integer is `-1`, `0`, or `+1`. The newtypes also contain escape hatches
-from the validation prior to conversion in the form of the `from_u8_unchecked`
-and `from_i8_unchecked` methods. These are provided for when performance is a concern,
-which is expected to be the case as these hashing functions will be used in tight loops.
-
-Given that these types are wrappers around `Vec` and slices, they should implement all
-traits that makes them usable in a similar way. This RFC doesn't provide example implementations,
-but the following is a non-exhaustive list of traits that will be required (in particular, for
-conveniently implementing the sponges presented here):
-
-+ `std::ops::Index` and the associated `std::slice::SliceIndex`;
-+ `std::ops::Deref` to derefence a `TritsBuf` into `Trits`;
-+ `std::iter::Iterator`;
+For the binary representation of the integer, the types `I384` (“signed” integer akin to `i64`), and `U384` (
+“unsigned” akin to `u64`) are defined:
 
 ```rust
-pub struct TritsBuf(Vec<i8>);
-pub struct Trits<'a>(&'a [i8]);
-pub struct TritsMut<'a>(&'a mut [i8]);
-
-struct FromU8Error;
-struct FromI8Error;
-
-// Similar impls for `TritsMut` and `TritsBuf`
-impl<'a> Trits<'a> {
-    pub fn from_i8_unchecked(v: &[i8]) -> Self {
-        Trits(v)
-    }
-
-    pub fn from_u8_unchecked(v: &[u8]) -> Self {
-        from_i8_unchecked(unsafe {
-            &*(self as *const _ as *const [i8])
-        })
-    }
+struct I384<E, T> {
+    inner: T,
+    _phantom: PhantomData<E>.
 }
 
-impl TritsBuf {
-    /// Create a new `TritsBuf` with a number of `capacity` elements, all
-    /// initialized to 0;
-    pub fn with_capacity(capacity: usize) -> Self {
-        Self(vec![0; usize])
-    }
+struct U384<E, T> {
+    inner: T,
+    _phantom: PhantomData<E>.
 }
+```
 
+`inner: T` for encoding the inner fixed-size arrays used for storing either
+bytes, `u8`, or integers, `u32`:
 
-impl<'_> TryFrom<&'_ u8> for Trits {
-    type Error = FromU8Error;
+```rust
+type U8Repr = [u8; 48];
+type U32Repr = [u32; 12];
+```
 
-    fn try_from(self) -> Result<Trits, Self::Error> {
-        for byte in self {
-            match byte {
-                0b0000_0000 | 0b1111_1111 | 0b0000_0001 => {},
-                _ => Err(FromU8Error)?,
-            }
-        }
+The phantom type `E` is used to encode endianness, `BigEndian` and
+`LittleEndian`. These are just used as marker types without any methods.
 
-        Ok( Trits::from_u8_unchecked(self) )
-        })
-    }
-}
+```rust
+struct BigEndian {}
+struct LittleEndian {}
+
+trait EndianType {}
+
+impl EndianType for BigEndian {}
+impl EndianType for LittleEndian {}
+```
+
+The underlying arrays and endianness are important, because `keccak` expects
+bytes as input, and because `Kerl` made the choice to revert the order of the
+integers in binary big int. When absorbing into the sponge the conversion thus
+flows like this (little and big are short for little and big endian, respectively):
+
+```
+Balanced t243 -> unbalanced t242 -> u32 little u384 -> u32 little i384 -> u8 big i384
+```
+
+When squeezing and thus converting back to ternary the conversion flows like this:
+
+```
+u8 big i384 -> u32 little i384 -> u32 little u384 -> unbalanced t243 -> balanced t243 -> balanced t242
+```
+
+To understand the implementation in the prototype, the most important methods are:
+
+```rust
+T242<Btrit>::from_i384_ignoring_mst
+T243<Utrit>::from_u384
+I384<LittleEndian, U32Repr>::from_t242
+I384<LittleEndian, U32Repr>::try_from_t242
+U384<LittleEndian, U32Repr>::add_inplace
+U384<LittleEndian, U32Repr>::add_digit_inplace
+U384<LittleEndian, U32Repr>::sub_inplace
+U384<LittleEndian, U32Repr>::from_t242
+U384<LittleEndian, U32Repr>::try_from_t243
 ```
 
 # Drawbacks
 
-+ Ternary is only handled within the crate as there is currently no common interface for it. Thus the present hashing
-  functions will perform extra operations which is not ideal when called repeatedly.
++ The associated constants `IN_LEN` and `OUT_LEN` have to be implemented for every hash function,
+  but don't fulfill a role on the type level.
++ `IN_LEN` and `OUT_LEN` might be considered more an implementation detail of the implementor of the
+  `Sponge` trait rather than a property of the interface.
++ All hash functions, no matter if they can fail or not, have to implement `Error`.
++ There are a lot of types. Is it important to encode that the most significant trit is `0` by having a `T242`?
 
 # Rationale and alternatives
 

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -25,7 +25,7 @@ Useful links:
 # Motivation
 
 One goal of the `bee` project is to make it possible to write nodes that are able to run on the current main net of
-IOTA. Nodes comprising the current main net are implemented using the IOTA reference implementation, version `iri
+IOTA. Nodes comprising the current main net are either implemented using the IOTA reference implementation, version `iri
 v1.8.1`, or using libraries compatible with it.
 
 In order to participate in the IOTA network, a node needs be able to construct valid messages that can be verified by
@@ -51,28 +51,35 @@ function that replaces the state memory using some input string (which can be th
 memory state is then the output. In the sponge metaphor, the process of replacing the memory state by an input string is
 said to *absorb* the input, while the process of producing an output is said to *squeeze out* an output.
 
-This RFC hence proposes to implement the `Curl-P-81` and `Kerl` sponge structures, together with same public methods.
-These are expected to be used like this:
+This RFC hence proposes to implement the `Curl` and `Kerl` sponge structures, with both being implement using the same
+or very similar function signatures. The shared interface is thus defined by convention, and there is no unifying
+`Sponge` trait.
+
+The hashes are expected to be used like this:
 
 ```rust
-// Create a Curl instance with default rounds number which is 81.
+// Create a Curl instance with 81 rounds.
+// This is equivalent to calling `Curl::new(81)`.
 let mut curl = Curl::default();
+
 // Assume this is a transaction and we want to digest a hash.
 let transaction = [0i8; 8019];
 let mut tx_hash = [0i8; 243];
 
-// `digest` is a combined method of curl which can separate with `absorb` & `squeeze` alternatively.
-// curl.absorb(&transaction);
-// curl.squeeze(&mut tx_hash);
-curl.digest(&transaction, &mut tx_hash);
+// Absorb the transaction.
+curl.absorb(&transaction);
+// And squeeze into the `tx_hash` buffer.
+curl.squeeze_into(&mut tx_hash);
+```
 
-// That said we have `Kerl` and would like to hash with this instead.
+```rust
+// Create a default Kerl instance. Kerl does not come with a configurable number of rounds, so that
+// `Kerl::new()` and `Kerl::default()` yield the same result.
 let mut kerl = Kerl::default();
 
-// Same public methods are called and signatures are not changed. Separate methods are still available.
-// kerl.absorb(&transaction);
-// kerl.squeeze(&mut tx_hash);
-kerl.digest(&transaction, &mut tx_hash);
+// `Kerl::digest` is a function that combines `Kerl::absorb` and `Kerl::squeeze`. `Kerl::digest_into`
+// combines `Kerl::absorb` with `Kerl::squeeze_into`. `Curl` provides the same methods.
+let tx_hash = kerl.digest(&transaction);
 ```
 
 Useful links:
@@ -258,8 +265,10 @@ impl Kerl {
 
 # Rationale and alternatives
 
-- This kind of sponge type provide a common interface suit for any type of sponge functions.
-- This type is idiomatic in Rust. Users are not required to know the implement details of each hash algorithm.
++ `Curl` and `Kerl` are fundamental to the `iri v1.8.1` main net. They are thus essential for compatibility with it.
++ It is not clear if a `Sponge` trait as a unifying interface would find use. The similar interfaces between `Curl`
+  and `Kerl` are thus defined by convention.
++ This type is idiomatic in Rust. Users are not required to know the implement details of each hash algorithm.
 - We still have option to just use `Digest` crate, but it's parameters are all type of `u8`. IOTA use trits as basic
   type which means this library may not fit our need. The ecosystem of this crate is also not fully mature yet. It may
 be a burden to add another dependency.

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -35,7 +35,7 @@ pub trait Sponge {
 ```
 # Drawbacks
 
-- Somebody may just want to use each function directly without moethods of this trait.
+- Somebody may just want to use each function directly without methods of this trait.
 - This trait only suit for sponge functions and also focus on ternary system. It's not compatible to other binary
 	cryptography.
 
@@ -48,7 +48,7 @@ pub trait Sponge {
 
 # Unresolved questions
 
-- Require and provided methods better resolve through RFC process.
+- Required and provided methods better resolve through RFC process.
 - Should we have low level traits defined like Digest? If so, should we also provide macro to implement these traits
 	easily?
 - Implementation of each hash functions and other utilities like HMAC should have separate RFCs for them.

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -5,13 +5,13 @@
 
 # Summary
 
-This RFC proposes the implementation of the cryptographic hash functions `Curl-P-81` and `Kerl`, and a geneeal interface
-for public methods.  `Curl-P-81` and `Kerl` are the two cryptographic hash functions used by `iri v1.8.1`, the IOTA
-reference implementation. As both are sponge constructions, they share a similar structure amenable to abstraction.
+This RFC proposes the implementation of the cryptographic hash functions `CurlP` and `Kerl`. `CurlP81`, a newtype for
+`CurlP` with 81 rounds, and `Kerl` are the two cryptographic hash functions used by `iri v1.8.1`, the IOTA reference
+implementation. Both are sponge constructions, and thus follow a very similar structure.
 
-In `iri v1.8.1`, `Curl-P-81` is used for generating transaction hashes, and as the cryptographic hash function in
-`PearlDiver`, its proof of work algorithm. `Kerl` on the other hand is used as part of all other operations requiring
-cryptographic security, namely address generation, signature generation and verification, and bundle hash calculation.
+In `iri v1.8.1`, `CurlP81` is used for generating transaction hashes and --- through the `PearlDiver` algorithm --- for
+proof of work calculations. `Kerl` on the other hand is used as part of all other operations requiring cryptographic
+security, namely address generation, signature generation and verification, and bundle hash calculation.
 
 Useful links:
 
@@ -21,7 +21,6 @@ Useful links:
 + [Troika specification](https://www.cyber-crypt.com/troika/)
 + [PearlDiver](...)
 + [`iri v1.8.1`](...)
-
 
 # Motivation
 

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -12,10 +12,11 @@ This RFC proposes the implementation of the cryptographic hash functions `CurlP`
 the IOTA reference implementation. All are sponge constructions, and thus follow a very similar architecture.
 
 In `iri v1.8.1`, `CurlP81`, `CurlP27` are used for generating transaction hashes and --- through the `PearlDiver`
-algorithm --- for proof of work calculations.  `CurlP81` is used in mainnet, while `CurlP27` is used in testnet. `Kerl`
+algorithm --- for proof of work calculations. `CurlP81` is used in mainnet, while `CurlP27` is used in testnet. `Kerl`
 on the other hand is used as part of all other operations requiring cryptographic security, namely address generation,
-signature generation and verification, and bundle hash calculation.
+signature generation and verification, and bundle hash calculation. It is also used for coordinator to produce milestones on the mainnet.
 
+This design is going to be the common interface of any sponge function. Users can expect each hash instance to provide
 Useful links:
 
 + [The sponge and duplex constructions](https://keccak.team/sponge_duplex.html)
@@ -117,7 +118,6 @@ trait Sponge {
         self.squeeze_into(buffer);
     }
 
-
     // Convenience function to absorb `input` and squeeze the sponge in one go, returning the output
     fn digest(&mut self, input: &Input) -> Output {
         self.absorb(input);
@@ -126,7 +126,6 @@ trait Sponge {
 }
 ```
 
-This design is going to be the common interface of any sponge function. Users can expect each hash instance to provide
 at least these public methods. Following the sponge metaphor, an input reference provided by the user is `absorb`ed, and
 an output will be `squeeze`d from the data structure. `digest` is a convenience method calling `absorb` and `squeeze` in
 one go. The `*_into` versions of these methods are for providing a buffer into which the calculated hashes are written.

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -33,27 +33,22 @@ pub trait Sponge {
 	fn reset(&mut self);
 }
 ```
-
 # Drawbacks
 
-// TODO
-Why should we *not* do this?
+- Somebody may just want to use each function directly without moethods of this trait.
+- This trait only suit for sponge functions and also focus on ternary system. It's not compatible to other binary
+	cryptography.
 
 # Rationale and alternatives
 
-// TODO
-- Why is this design the best in the space of possible designs?
-- What other designs have been considered and what is the rationale for not
-  choosing them?
-- What is the impact of not doing this?
+- `Sponge` trait provide a common interface suit for any type of sponge functions.
+- This trait is idiomatic in Rust. Users are not required to know the implement details of each hash algorithm.
+- We still have option to just use `Digest` crate, but it's parameters are all type of `u8`. IOTA use trits as basic
+	type which means this library may not fit our need.
 
 # Unresolved questions
 
-// TODO
-- What parts of the design do you expect to resolve through the RFC process
-  before this gets merged?
-- What parts of the design do you expect to resolve through the implementation
-  of this feature before stabilization?
-- What related issues do you consider out of scope for this RFC that could be
-  addressed in the future independently of the solution that comes out of this
-  RFC?
+- Require and provided methods better resolve through RFC process.
+- Should we have low level traits defined like Digest? If so, should we also provide macro to implement these traits
+	easily?
+- Implementation of each hash functions and other utilities like HMAC should have separate RFCs for them.

--- a/text/0000-hash/0000-hash.md
+++ b/text/0000-hash/0000-hash.md
@@ -93,33 +93,30 @@ The cryptographic hash functions in this RFC are implemented in terms of the `Sp
 
 ```rust
 trait Sponge {
-    type Input;
-    type Output: Default;
-
     // Absorb `input` into the sponge
-    fn absorb(&mut self, input: &Input);
+    fn absorb(&mut self, input: &[u8]);
 
     // Reset the inner state of the sponge
     fn reset(&mut self);
 
     // Squeeze the sponge into a buffer
-    fn squeeze_into(&mut self, buffer: &mut Output)
+    fn squeeze_into(&mut self, buf: &mut [u8])
 
     // Squeeze the sponge and return the output
-    fn squeeze(&mut self) -> Output {
-        let mut output: Self::Output::default();
+    fn squeeze(&mut self) -> Vec<u8> {
+        let mut output: Vec::new();
         self.squeeze_into(&mut output);
         output
     }
 
     // Convenience function to absorb `input` and squeeze the sponge into a buffer in one go.
-    fn digest_into(&mut self, input: &Input, buffer: &mut Output)
+    fn digest_into(&mut self, input: &[u8], buf: &mut [u8])
         self.absorb(input);
-        self.squeeze_into(buffer);
+        self.squeeze_into(buf);
     }
 
     // Convenience function to absorb `input` and squeeze the sponge in one go, returning the output
-    fn digest(&mut self, input: &Input) -> Output {
+    fn digest(&mut self, input: &[u8]) -> Vec<u8> {
         self.absorb(input);
         self.squeeze();
     }
@@ -199,10 +196,7 @@ impl CurlP {
 
 ```rust
 impl Sponge for CurlP {
-    type Input = [u8];
-    type Output = Vec<u8>;
-
-    pub fn absorb(&mut self, input: &Self::Input) {
+    pub fn absorb(&mut self, input: &[u8]) {
         for c in input.chunks(HASH_LENGTH) {
             self.state[0..c.len()].copy_from_slice(c);
             self.transform();
@@ -215,18 +209,18 @@ impl Sponge for CurlP {
     }
 
     /// Squeeze trits out of the sponge and copy them into `out`
-    pub fn squeeze_into(&mut self, buf: &mut Output) {
-        let trit_count = output.len();
+    pub fn squeeze_into(&mut self, buf: &mut [u8]) {
+        let trit_count = buf.len();
         let hash_count = trit_count / HASH_LENGTH;
 
         for i in 0..hash_count {
-            output[i * HASH_LENGTH..(i + 1) * HASH_LENGTH]
+            buf[i * HASH_LENGTH..(i + 1) * HASH_LENGTH]
                 .copy_from_slice(&self.state[0..HASH_LENGTH]);
             self.transform();
         }
 
         let last = trit_count - hash_count * HASH_LENGTH;
-        output[trit_count - last..].copy_from_slice(&self.state[0..last]);
+        buf[trit_count - last..].copy_from_slice(&self.state[0..last]);
         if trit_count % HASH_LENGTH != 0 {
             self.transform();
         }
@@ -254,7 +248,6 @@ impl CurlP81 {
 }
 ```
 
-
 ## Design of `Kerl`
 
 ```rust
@@ -269,10 +262,7 @@ impl Kerl {
 }
 
 impl Sponge for Kerl {
-    type Input = [u8];
-    type Output = Vec<u8>;
-
-    pub fn absorb(&mut self, trits: &Input) {
+    pub fn absorb(&mut self, trits: &[u8]) {
         assert_eq!(trits.len() % TRIT_LENGTH, 0);
         let mut bytes: [u8; BYTE_LENGTH] = [0; BYTE_LENGTH];
 
@@ -282,11 +272,11 @@ impl Sponge for Kerl {
         }
     }
 
-    pub fn squeeze_into(&mut self, out: &mut Output) {
-        assert_eq!(out.len() % TRIT_LENGTH, 0);
+    pub fn squeeze_into(&mut self, buf: &mut [u8]) {
+        assert_eq!(buf.len() % TRIT_LENGTH, 0);
         let mut bytes: [u8; BYTE_LENGTH] = [0; BYTE_LENGTH];
 
-        for chunk in out.chunks_mut(TRIT_LENGTH) {
+        for chunk in buf.chunks_mut(TRIT_LENGTH) {
             self.0.pad();
             self.0.fill_block();
             self.0.squeeze(&mut bytes);


### PR DESCRIPTION
[Rendered](https://github.com/wusyong/bee-rfcs/blob/crypto/text/0000-hash/0000-hash.md)

This is the draft for any hash type especially for sponge function. Other functionalities like hash algorithms, HMAC, and signature schemes should be separate RFCs. Any suggestion is welcome. The implementation would simply look like [this](https://github.com/wusyong/sponge-preivew/blob/master/src/lib.rs).
